### PR TITLE
Remove twitter link

### DIFF
--- a/data/gui.xml
+++ b/data/gui.xml
@@ -802,10 +802,6 @@
           <param name="type" value="url" />
           <param name="path" value="/release-notes/" />
         </item>
-        <item command="Launch" text="Twitter">
-          <param name="type" value="url" />
-          <param name="path" value="http://twitter.com/aseprite" />
-        </item>
         <separator />
         <item command="Launch" text="&amp;Donate">
           <param name="type" value="url" />


### PR DESCRIPTION
This changeset removes the link to Aseprite Twitter account from the "Help" menu.