### PR TITLE
Add support for XDG Base Directory spec

### DIFF
--- a/src/app/resource_finder.cpp
+++ b/src/app/resource_finder.cpp
@@ -104,9 +104,16 @@ void ResourceFinder::includeDataDir(const char* filename)
 
 #else
 
-  // $HOME/.config/libresprite/filename
-  sprintf(buf, ".config/libresprite/data/%s", filename);
-  includeHomeDir(buf);
+
+  const char* xdgdir = std::getenv("XDG_CONFIG_HOME");
+  if((xdgdir) && (*xdgdir)) {
+    sprintf(buf, "%s/libresprite/data/%s", xdgdir, filename); // $XDG_CONFIG_HOME/libresprite/data/filename
+    addPath(buf);
+  }
+  else {
+    sprintf(buf, ".config/libresprite/data/%s", filename); // $HOME/.config/libresprite/data/filename
+    includeHomeDir(buf);
+  }
 
   // $BINDIR/data/filename
   sprintf(buf, "data/%s", filename);
@@ -173,8 +180,15 @@ void ResourceFinder::includeUserDir(const char* filename)
 
 #else
 
-  // $HOME/.config/libresprite/filename
-  includeHomeDir((std::string(".config/libresprite/") + filename).c_str());
+  char buf[4096];
+  const char* xdgdir = std::getenv("XDG_CONFIG_HOME");
+  if((xdgdir) && (*xdgdir)) {
+    sprintf(buf, "%s/libresprite/%s", xdgdir, filename); // $XDG_CONFIG_HOME/libresprite/filename
+    addPath(buf);
+  }
+  else
+    includeHomeDir((std::string(".config/libresprite/") + filename).c_str());   // $HOME/.config/libresprite/filename
+
 
 #endif
 }

--- a/src/app/resource_finder.h
+++ b/src/app/resource_finder.h
@@ -48,7 +48,8 @@ namespace app {
     // - If the app is installed, the filename will be inside
     //   %AppData% location
     // For Unix-like platforms:
-    // - The filename will be in $HOME/.config/libresprite/
+    // - The filename will be in $XDG_CONFIG_HOME/libresprite/
+    // or if $XDG_CONFIG_HOME is not defined, $HOME/.config/libresprite/
     void includeUserDir(const char* filename);
 
     void includeDesktopDir(const char* filename);


### PR DESCRIPTION
LibreSprite hardcodes the configuration directory to be ~/.config instead of checking for XDG_CONFIG_HOME variable.
Normally these will match up unless if the user decides to change the default value of XDG_CONFIG_HOME or if it's packaged as a flatpak.