### PR TITLE
Travis CI - AppImage Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,61 @@
 language: cpp
+compiler: gcc
+os: linux
+dist: bionic
+cache: ccache
 
-compiler:
-  - clang
-  - gcc
+addons:
+    apt:
+        sources:
+            - ubuntu-toolchain-r-test
+        packages:
+            - g++-4.8
+            - cmake
+            - ninja-build
+            - ccache
+            - libx11-dev
+            - libxcursor-dev
 
 env:
-  matrix:
-    - SHARED=OFF
-    - SHARED=ON
+  - SHARED=OFF
 
 before_install:
-  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-  - sudo apt-get update -qq
   - if [ "$SHARED" == "ON" ]; then sudo apt-get install -y libcurl4-openssl-dev libgif-dev libfreetype6-dev libjpeg-dev libz-dev libpng-dev libtinyxml-dev libpixman-1-dev liballegro4.2-dev ; fi
-  - sudo apt-get install -y -qq g++-4.8
-  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8"; fi
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ] && [ "$CXX" = "g++" ]; then export CXX="g++-4.8"; fi
 
 before_script:
+  - ccache -z
   - mkdir build
   - cd build
-  - cmake .. -DUSE_SHARED_CURL=$SHARED -DUSE_SHARED_GIFLIB=$SHARED -DUSE_SHARED_FREETYPE=$SHARED -DUSE_SHARED_JPEGLIB=$SHARED -DUSE_SHARED_ZLIB=$SHARED -DUSE_SHARED_LIBPNG=$SHARED -DUSE_SHARED_TINYXML=$SHARED -DUSE_SHARED_PIXMAN=$SHARED -DUSE_SHARED_ALLEGRO4=$SHARED -DENABLE_TESTS=ON
+  - cmake -G Ninja .. -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/build/install -DWITH_DESKTOP_INTEGRATION=ON -DUSE_SHARED_CURL=$SHARED -DUSE_SHARED_GIFLIB=$SHARED -DUSE_SHARED_FREETYPE=$SHARED -DUSE_SHARED_JPEGLIB=$SHARED -DUSE_SHARED_ZLIB=$SHARED -DUSE_SHARED_LIBPNG=$SHARED -DUSE_SHARED_TINYXML=$SHARED -DUSE_SHARED_PIXMAN=$SHARED -DUSE_SHARED_ALLEGRO4=$SHARED -DENABLE_TESTS=ON
 
 script:
-  - "make"
-  - "ctest --output-on-failure"
+  - ninja libresprite
+  - ninja install
+  - cd "${TRAVIS_BUILD_DIR}"
+  - ccache -s
+
+after_success:
+  - |
+    if [ "$TRAVIS_BRANCH" == "master" ]; then
+      cd build
+      wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+      chmod +x linuxdeploy-x86_64.AppImage
+      ./linuxdeploy-x86_64.AppImage --appdir AppDir
+      cp -r install/share/icons/* AppDir/usr/share/icons
+      mv install/share/libresprite/data/ AppDir/usr/bin/
+      ./linuxdeploy-x86_64.AppImage --appdir AppDir  -e install/bin/libresprite -d ../desktop/libresprite.desktop --output appimage
+      mkdir out
+      mv LibreSprite-*.AppImage -t out
+      ls -lh out/*
+      wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
+      bash upload.sh out/*
+    fi
+
+branches:
+    except:
+      - # Do not build tags that we create when we upload to GitHub Releases
+      - /^(?i:continuous.*)$/
+
+notifications:
+  email: false


### PR DESCRIPTION
Updates .travis to support AppImage x64 deployment. [Here](https://github.com/PerryHugh/LibreSprite/releases/tag/continuous) is an example, feel free to test.
* AppImages are deployed to the GitHub releases page under the tag "Continuous" when a merge to master takes place. This can be expanded to support feature branch deployment for testing if desired later. The previous "Continuous" tagged release is overwritten.
* Requires a [GITHUB_TOKEN](https://github.com/probonopd/uploadtool/blob/master/README.md) to be added to the official LibreSprite repository.
* MacOS support is seemingly not doable at this time. I tried to get Skia working, but unfortunately the old version's scripts no longer has authentication to Google's servers to download resources, making them fail to build. Building with a newer version of Skia fails due to API changes.
* Windows support was not attempted, if someone adds it they would have to use the Allegro 4 back-end.
* In addition, ccache is used for faster build times, currently Travis CI runs at just over 5 minutes.

_Closes  #19_