### PR TITLE
Default canvas size shortcut on C

### DIFF
--- a/data/gui.xml
+++ b/data/gui.xml
@@ -58,6 +58,7 @@
       <key command="KeyboardShortcuts" shortcut="Ctrl+Alt+Shift+K" mac="Cmd+Alt+Shift+K" />
       <!-- Sprite -->
       <key command="SpriteProperties" shortcut="Ctrl+P" mac="Cmd+P" />
+      <key command="CanvasSize" shortcut="C" />
       <!-- Layer -->
       <key command="LayerProperties" shortcut="Shift+P" />
       <key command="LayerVisibility" shortcut="Shift+X" />


### PR DESCRIPTION
Hello, first PR here. I use ASEprite every day to work and I'm super glad to have found a free software fork :)
Long story short, a few (to me) essential things are missing, so I've decided starting with the most basic one: the "C" shortcut for resizing the canvas. I hope it's fine!