### PR TITLE
Add Layer Name length field to spec

### DIFF
--- a/docs/files/ase.txt
+++ b/docs/files/ase.txt
@@ -177,6 +177,7 @@ Layer Chunk (0x2004)
   BYTE          Opacity
                   Note: valid only if file header flags field has bit 1 set
   BYTE[3]       For future (set to zero)
+  WORD          Length of layer name
   STRING        Layer name
 
 


### PR DESCRIPTION
Adding extra field for length of layer name which is in the file format, but not in the document that describes the format.