### PR TITLE
Add default shortcuts for layers "Merge down" and "Duplicate" actions

### DIFF
--- a/data/gui.xml
+++ b/data/gui.xml
@@ -15,8 +15,8 @@
       <key command="SaveFileCopyAs" shortcut="Ctrl+Alt+Shift+S" mac="Cmd+Alt+Shift+S" />
       <key command="CloseFile" shortcut="Ctrl+W" mac="Cmd+W" />
       <key command="CloseAllFiles" shortcut="Ctrl+Shift+W" mac="Cmd+Shift+W" />
-      <key command="ImportSpriteSheet" shortcut="Ctrl+I" mac="Cmd+I" />
-      <key command="ExportSpriteSheet" shortcut="Ctrl+E" mac="Cmd+E" />
+      <key command="ImportSpriteSheet" shortcut="Ctrl+Alt+I" mac="Cmd+Alt+I" />
+      <key command="ExportSpriteSheet" shortcut="Ctrl+Alt+E" mac="Cmd+Alt+E" />
       <key command="RepeatLastExport" shortcut="Ctrl+Shift+X" mac="Cmd+Shift+X" />
       <key command="AdvancedMode" shortcut="F11" />
       <key command="DeveloperConsole" shortcut="F12" />
@@ -63,6 +63,8 @@
       <key command="LayerProperties" shortcut="Shift+P" />
       <key command="LayerVisibility" shortcut="Shift+X" />
       <key command="NewLayer" shortcut="Shift+N" />
+      <key command="DuplicateLayer" shortcut="Ctrl+J" mac="Cmd+J" />
+      <key command="MergeDownLayer" shortcut="Ctrl+E" mac="Cmd+E" />
       <key command="GotoPreviousLayer" shortcut="Down" context="Normal" />
       <key command="GotoNextLayer" shortcut="Up" context="Normal" />
       <!-- Frame -->

--- a/data/gui.xml
+++ b/data/gui.xml
@@ -62,7 +62,7 @@
       <!-- Layer -->
       <key command="LayerProperties" shortcut="Shift+P" />
       <key command="LayerVisibility" shortcut="Shift+X" />
-      <key command="NewLayer" shortcut="Shift+N" />
+      <key command="NewLayer" shortcut="Ctrl+Shift+N" mac="Cmd+Shift+N"/>
       <key command="DuplicateLayer" shortcut="Ctrl+J" mac="Cmd+J" />
       <key command="MergeDownLayer" shortcut="Ctrl+E" mac="Cmd+E" />
       <key command="GotoPreviousLayer" shortcut="Down" context="Normal" />


### PR DESCRIPTION
One of the things I keep doing by mistake is pressing `Ctrl+J` to duplicate layers and `Ctrl+E` for merging them. This happens because both Krita and Photoshop have the same shortcuts and... well, I think that LibreSprite could follow the same standard. If people don't agree with these shortcuts, please at least let's put some by default because is very annoying not having them.

As `Ctrl+E` was the default shortcut for the spritesheet editor, I've moved this one and the importer onto `Ctrl+Alt+E` and `Ctrl+Alt+I`, as I think these actions are way more sporadic than merging and duplicating layers (I wanted to use `Shift` instead of `Alt` but `Ctrl+Shift+I` is the invert selection shortcut, another standard, so I didn't touch it)


