### PR TITLE
Add correct copyright notices in files edited since the fork

### DIFF
--- a/data/gui.xml
+++ b/data/gui.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- LibreSprite -->
-<!-- Copyright (C) 2001-2016 by David Capello -->
+<!-- Aseprite    | Copyright (C) 2001-2016  David Capello -->
+<!-- LibreSprite | Copyright (C) 2017-2021  LibreSprite contributors -->
 <gui version="1.1.8-dev">
   <!-- Keyboard shortcuts -->
   <keyboard version="1">

--- a/data/pref.xml
+++ b/data/pref.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- LibreSprite -->
-<!-- Copyright (C) 2014-2016 by David Capello -->
+<!-- Aseprite    | Copyright (C) 2014-2016  David Capello -->
+<!-- LibreSprite | Copyright (C) 2016-2021  LibreSprite contributors -->
 <preferences>
 
   <types>

--- a/data/skins/default/skin.xml
+++ b/data/skins/default/skin.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Aseprite    | Copyright (C) 2001-2016  David Capello -->
+<!-- LibreSprite | Copyright (C) 2021       LibreSprite contributors -->
 <skin name="Default"
       author="Ilija Melentijevic &amp; David Capello"
       url="http://ilkke.blogspot.com/">

--- a/data/widgets/home_view.xml
+++ b/data/widgets/home_view.xml
@@ -1,5 +1,5 @@
-<!-- LibreSprite -->
-<!-- Copyright (C) 2001-2015 by David Capello -->
+<!-- Aseprite    | Copyright (C) 2001-2015  David Capello -->
+<!-- LibreSprite | Copyright (C) 2021       LibreSprite contributors -->
 <gui>
   <vbox noborders="true" id="home_view" border="4" childspacing="2" expansive="true">
     <hbox noborders="true" id="recover_sprites_placeholder">

--- a/data/widgets/send_crash.xml
+++ b/data/widgets/send_crash.xml
@@ -1,5 +1,5 @@
-<!-- LibreSprite -->
-<!-- Copyright (C) 2014, 2016 by David Capello -->
+<!-- Aseprite    | Copyright (C) 2014-2016  David Capello -->
+<!-- LibreSprite | Copyright (C) 2018       LibreSprite contributors -->
 <gui>
 <window text="Crash Report" id="send_crash">
   <vbox>

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2016  David Capello
+// Aseprite    - Copyright (C) 2001-2016  David Capello
+// LibreSprite - Copyright (C) 2018-2021  LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/file/ase_format.cpp
+++ b/src/app/file/ase_format.cpp
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2016  David Capello
+// Aseprite    | Copyright (C) 2001-2016  David Capello
+// LibreSprite | Copyright (C) 2021       LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/file/bmp_format.cpp
+++ b/src/app/file/bmp_format.cpp
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2015  David Capello
+// Aseprite    | Copyright (C) 2001-2015  David Capello
+// LibreSprite | Copyright (C) 2021       LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/file/file.cpp
+++ b/src/app/file/file.cpp
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2016  David Capello
+// Aseprite    | Copyright (C) 2001-2016  David Capello
+// LibreSprite | Copyright (C) 2021       LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/file/file_format.cpp
+++ b/src/app/file/file_format.cpp
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2015  David Capello
+// Aseprite    | Copyright (C) 2001-2015  David Capello
+// LibreSprite | Copyright (C) 2021       LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/file/file_format.h
+++ b/src/app/file/file_format.h
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2015  David Capello
+// Aseprite    | Copyright (C) 2001-2015  David Capello
+// LibreSprite | Copyright (C) 2021       LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/file/fli_format.cpp
+++ b/src/app/file/fli_format.cpp
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2015  David Capello
+// Aseprite    | Copyright (C) 2001-2015  David Capello
+// LibreSprite | Copyright (C) 2021       LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/file/gif_format.cpp
+++ b/src/app/file/gif_format.cpp
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2015  David Capello
+// Aseprite    | Copyright (C) 2001-2015  David Capello
+// LibreSprite | Copyright (C) 2021       LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/file/ico_format.cpp
+++ b/src/app/file/ico_format.cpp
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2015  David Capello
+// Aseprite    | Copyright (C) 2001-2015  David Capello
+// LibreSprite | Copyright (C) 2021       LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/file/jpeg_format.cpp
+++ b/src/app/file/jpeg_format.cpp
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2015  David Capello
+// Aseprite    | Copyright (C) 2001-2015  David Capello
+// LibreSprite | Copyright (C) 2021       LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/file/pcx_format.cpp
+++ b/src/app/file/pcx_format.cpp
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2015  David Capello
+// Aseprite    | Copyright (C) 2001-2015  David Capello
+// LibreSprite | Copyright (C) 2021       LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/file/pixly_format.cpp
+++ b/src/app/file/pixly_format.cpp
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2016  Carlo "zED" Caputo
+// Aseprite    | Copyright (C) 2016  Carlo "zED" Caputo
+// LibreSprite | Copyright (C) 2021  LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/file/png_format.cpp
+++ b/src/app/file/png_format.cpp
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2016  David Capello
+// Aseprite    | Copyright (C) 2001-2016  David Capello
+// LibreSprite | Copyright (C) 2021       LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/file/tga_format.cpp
+++ b/src/app/file/tga_format.cpp
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2015  David Capello
+// Aseprite    | Copyright (C) 2001-2015  David Capello
+// LibreSprite | Copyright (C) 2021       LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/file/webp_format.cpp
+++ b/src/app/file/webp_format.cpp
@@ -1,6 +1,5 @@
-// Aseprite
-// Copyright (C) 2015 Gabriel Rauter
-// Copyright (C) 2015 David Capello
+// Aseprite    | Copyright (C) 2015  Gabriel Rauter, David Capello
+// LibreSprite | Copyright (C) 2021  LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/ini_file.cpp
+++ b/src/app/ini_file.cpp
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2016  David Capello
+// Aseprite    | Copyright (C) 2001-2016  David Capello
+// LibreSprite | Copyright (C) 2018       LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/log.cpp
+++ b/src/app/log.cpp
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2016  David Capello
+// Aseprite    | Copyright (C) 2001-2016  David Capello
+// LibreSprite | Copyright (C) 2018       LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/resource_finder.cpp
+++ b/src/app/resource_finder.cpp
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2016  David Capello
+// Aseprite    | Copyright (C) 2001-2016  David Capello
+// LibreSprite | Copyright (C) 2018-2020  LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/resource_finder.h
+++ b/src/app/resource_finder.h
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2016  David Capello
+// Aseprite    | Copyright (C) 2001-2016  David Capello
+// LibreSprite | Copyright (C) 2018-2020  LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/tools/symmetry.cpp
+++ b/src/app/tools/symmetry.cpp
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2015  David Capello
+// Aseprite    | Copyright (C) 2015  David Capello
+// LibreSprite | Copyright (C) 2021  LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/tools/symmetry.h
+++ b/src/app/tools/symmetry.h
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2015  David Capello
+// Aseprite    | Copyright (C) 2015  David Capello
+// LibreSprite | Copyright (C) 2021  LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/ui/context_bar.cpp
+++ b/src/app/ui/context_bar.cpp
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2016  David Capello
+// Aseprite    | Copyright (C) 2001-2016  David Capello
+// LibreSprite | Copyright (C) 2021       LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/ui/editor/editor.cpp
+++ b/src/app/ui/editor/editor.cpp
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2016  David Capello
+// Aseprite    | Copyright (C) 2001-2016  David Capello
+// LibreSprite | Copyright (C) 2021       LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/ui/editor/moving_symmetry_state.cpp
+++ b/src/app/ui/editor/moving_symmetry_state.cpp
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2015  David Capello
+// Aseprite    | Copyright (C) 2015  David Capello
+// LibreSprite | Copyright (C) 2021  LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/ui/editor/moving_symmetry_state.h
+++ b/src/app/ui/editor/moving_symmetry_state.h
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2015-2016  David Capello
+// Aseprite    | Copyright (C) 2015-2016  David Capello
+// LibreSprite | Copyright (C) 2021       LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/ui/editor/standby_state.cpp
+++ b/src/app/ui/editor/standby_state.cpp
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2016  David Capello
+// Aseprite    | Copyright (C) 2001-2016  David Capello
+// LibreSprite | Copyright (C) 2021       LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/ui/editor/standby_state.h
+++ b/src/app/ui/editor/standby_state.h
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2016  David Capello
+// Aseprite    | Copyright (C) 2001-2016  David Capello
+// LibreSprite | Copyright (C) 2021       LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/ui/editor/tool_loop_impl.cpp
+++ b/src/app/ui/editor/tool_loop_impl.cpp
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2016  David Capello
+// Aseprite    | Copyright (C) 2001-2016  David Capello
+// LibreSprite | Copyright (C) 2021       LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/ui/home_view.cpp
+++ b/src/app/ui/home_view.cpp
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2016  David Capello
+// Aseprite    | Copyright (C) 2001-2016  David Capello
+// LibreSprite | Copyright (C) 2021       LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/ui/home_view.h
+++ b/src/app/ui/home_view.h
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2016  David Capello
+// Aseprite    | Copyright (C) 2001-2016  David Capello
+// LibreSprite | Copyright (C) 2021       LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/ui/main_window.cpp
+++ b/src/app/ui/main_window.cpp
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2016  David Capello
+// Aseprite    | Copyright (C) 2001-2016  David Capello
+// LibreSprite | Copyright (C) 2021       LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/app/ui/main_window.h
+++ b/src/app/ui/main_window.h
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2015  David Capello
+// Aseprite    | Copyright (C) 2001-2015  David Capello
+// LibreSprite | Copyright (C) 2021       LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as

--- a/src/config.h
+++ b/src/config.h
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2016  David Capello
+// Aseprite    | Copyright (C) 2001-2016  David Capello
+// LibreSprite | Copyright (C) 2018-2021  LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as
@@ -29,7 +29,7 @@
 #define WEBSITE                 "https://github.com/LibreSprite/LibreSprite/"
 #define WEBSITE_DOWNLOAD        WEBSITE "releases/"
 #define WEBSITE_CONTRIBUTORS    WEBSITE "graphs/contributors/"
-#define COPYRIGHT               "Copyright (C) 2001-2016 David Capello, 2016-2018 LibreSprite contributors"
+#define COPYRIGHT               "Copyright (C) 2001-2016 David Capello, 2016-2021 LibreSprite contributors"
 
 #include "base/base.h"
 #include "base/debug.h"

--- a/src/doc/blend_internals.h
+++ b/src/doc/blend_internals.h
@@ -1,5 +1,6 @@
-// Aseprite Document Library
-// Copyright (c) 2001-2015 David Capello
+// LibreSprite Document Library
+// Copyright (C) 2001-2015 David Capello
+// Copyright (C) 2021      LibreSprite contributors
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.

--- a/src/main/resources_win32.rc
+++ b/src/main/resources_win32.rc
@@ -23,7 +23,7 @@ BEGIN
             VALUE "FileDescription", "LibreSprite - Animated sprites editor & pixel art tool"
             VALUE "FileVersion", "1,0,0,0"
             VALUE "InternalName", "libresprite"
-            VALUE "LegalCopyright", "Copyright (C) 2001-2016 by David Capello, 2016-2018 LibreSprite contributors"
+            VALUE "LegalCopyright", "Copyright (C) 2001-2016 by David Capello, 2016-2021 LibreSprite contributors"
             VALUE "OriginalFilename", "libresprite.exe"
             VALUE "ProductName", "LIBRESPRITE"
             VALUE "ProductVersion", "1,0,0,0"


### PR DESCRIPTION
Closes #144 

In the end I've opted for adding the year an Aseprite file was edited for the first time and (if different) the last year it was edited again. Basically because of this https://stackoverflow.com/questions/9039698/which-years-to-write-into-copyright-header

**Q**: have you checked every commit manually to be sure of the year?
Yes I have

I've also used "LibreSprite contributors" as the copyright owner, which was used by @akien-mga in a few files already. I think contributors can be listed in [here](https://github.com/LibreSprite/LibreSprite/blob/master/CONTRIBUTORS.md), without being at each other's throats for whose name should be in a specific file.

Also, it'd be nice to have a template for PRs that asks people if they've checked and eventually updated the year in the file(s) they've touched