### PR TITLE
Allow extending app_menus and move submenu-specific code out

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -316,9 +316,11 @@ add_library(app-lib
   pref/preferences.cpp
   project.cpp
   recent_files.cpp
+  recent_files_menu.cpp
   res/palettes_loader_delegate.cpp
   res/resources_loader.cpp
   resource_finder.cpp
+  script/script_menu.cpp
   script/app_object.cpp
   script/app_scripting.cpp
   script/console_object.cpp

--- a/src/app/app_menus.h
+++ b/src/app/app_menus.h
@@ -10,9 +10,12 @@
 #define APP_APP_MENUS_H_INCLUDED
 #pragma once
 
+#include <unordered_map>
 #include "base/connection.h"
 #include "base/disable_copying.h"
 #include "base/unique_ptr.h"
+#include "recent_files_menu.h"
+#include "script/script_menu.h"
 #include "ui/base.h"
 #include "ui/menu.h"
 
@@ -28,52 +31,48 @@ namespace app {
 
   // Class to handle/get/reload available menus in gui.xml file.
   class AppMenus {
-    AppMenus();
+    AppMenus() = default;
     DISABLE_COPYING(AppMenus);
 
   public:
     static AppMenus* instance();
 
     void reload();
+    void rebuildRecentList();
+    void rebuildScriptsList();
 
-    // Updates the menu of recent files.
-    bool rebuildRecentList();
-    bool rebuildScriptsList();
+    template <typename Type=Menu>
+    Type* getById(const std::string& id) {
+        auto iterator = m_identifiedWidgets.find(id);
+        if (iterator == m_identifiedWidgets.end())
+            return nullptr;
+        return dynamic_cast<Type*>(iterator->second);
+    }
 
-    Menu* getRootMenu() { return m_rootMenu; }
-    MenuItem* getRecentListMenuitem() { return m_recentListMenuitem; }
-    Menu* getTabPopupMenu() { return m_tabPopupMenu; }
-    Menu* getDocumentTabPopupMenu() { return m_documentTabPopupMenu; }
-    Menu* getLayerPopupMenu() { return m_layerPopupMenu; }
-    Menu* getFramePopupMenu() { return m_framePopupMenu; }
-    Menu* getCelPopupMenu() { return m_celPopupMenu; }
-    Menu* getCelMovementPopupMenu() { return m_celMovementPopupMenu; }
-    Menu* getFrameTagPopupMenu() { return m_frameTagPopupMenu; }
-    Menu* getPalettePopupMenu() { return m_palettePopupMenu; }
-    Menu* getInkPopupMenu() { return m_inkPopupMenu; }
+    Menu* getRootMenu() { return getById("main_menu"); }
+    Menu* getTabPopupMenu() { return getById("tab_popup"); }
+    Menu* getDocumentTabPopupMenu() { return getById("document_tab_popup"); }
+    Menu* getLayerPopupMenu() { return getById("layer_popup"); }
+    Menu* getFramePopupMenu() { return getById("frame_popup"); }
+    Menu* getCelPopupMenu() { return getById("cel_popup"); }
+    Menu* getCelMovementPopupMenu() { return getById("cel_movement_popup"); }
+    Menu* getFrameTagPopupMenu() { return getById("frame_tag_popup"); }
+    Menu* getPalettePopupMenu() { return getById("palette_popup"); }
+    Menu* getInkPopupMenu() { return getById("ink_popup"); }
 
     void applyShortcutToMenuitemsWithCommand(Command* command, const Params& params, Key* key);
 
   private:
-    Menu* loadMenuById(TiXmlHandle& handle, const char *id);
+    void loadMenus(TiXmlHandle& handle);
     Menu* convertXmlelemToMenu(TiXmlElement* elem);
     Widget* convertXmlelemToMenuitem(TiXmlElement* elem);
     Widget* createInvalidVersionMenuitem();
     void applyShortcutToMenuitemsWithCommand(Menu* menu, Command* command, const Params& params, Key* key);
+    void clearIdentifiedWidgets();
 
-    base::UniquePtr<Menu> m_rootMenu;
-    MenuItem* m_recentListMenuitem;
-    Menu* m_scriptsListMenu;
-    base::UniquePtr<Menu> m_tabPopupMenu;
-    base::UniquePtr<Menu> m_documentTabPopupMenu;
-    base::UniquePtr<Menu> m_layerPopupMenu;
-    base::UniquePtr<Menu> m_framePopupMenu;
-    base::UniquePtr<Menu> m_celPopupMenu;
-    base::UniquePtr<Menu> m_celMovementPopupMenu;
-    base::UniquePtr<Menu> m_frameTagPopupMenu;
-    base::UniquePtr<Menu> m_palettePopupMenu;
-    base::UniquePtr<Menu> m_inkPopupMenu;
-    base::ScopedConnection m_recentFilesConn;
+    RecentFilesMenu m_recentFilesMenu;
+    ScriptMenu m_scriptMenu;
+    std::unordered_map<std::string, Widget*> m_identifiedWidgets;
   };
 
 } // namespace app

--- a/src/app/commands/cmd_keyboard_shortcuts.cpp
+++ b/src/app/commands/cmd_keyboard_shortcuts.cpp
@@ -577,9 +577,10 @@ private:
   }
 
   void fillList(ListBox* listbox, Menu* menu, int level) {
+    auto recentList = AppMenus::instance()->getById<MenuItem>("recent_list");
     for (auto child : menu->children()) {
       if (AppMenuItem* menuItem = dynamic_cast<AppMenuItem*>(child)) {
-        if (menuItem == AppMenus::instance()->getRecentListMenuitem())
+        if (menuItem == recentList)
           continue;
 
         KeyItem* keyItem = new KeyItem(

--- a/src/app/recent_files_menu.cpp
+++ b/src/app/recent_files_menu.cpp
@@ -1,0 +1,68 @@
+// LibreSprite
+// Copyright (C) 2021 LibreSprite contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 2 as
+// published by the Free Software Foundation.
+
+#include "recent_files_menu.h"
+#include "app.h"
+#include "app_menus.h"
+#include "commands/command.h"
+#include "commands/commands.h"
+#include "commands/params.h"
+#include "ui/app_menuitem.h"
+#include "base/bind.h"
+#include "base/path.h"
+#include "recent_files.h"
+
+namespace app {
+
+using namespace ui;
+
+RecentFilesMenu::RecentFilesMenu()
+{
+  auto& Changed = App::instance()->recentFiles()->Changed;
+  m_recentFilesConn = Changed.connect(base::Bind(&RecentFilesMenu::rebuildRecentList, this));
+}
+
+void RecentFilesMenu::rebuildRecentList()
+{
+    auto list_menuitem = app::AppMenus::instance()->getById<MenuItem>("recent_list");
+    if (!list_menuitem || list_menuitem->hasSubmenuOpened()) return;
+    Command* cmd_open_file = CommandsModule::instance()->getCommandByName(CommandId::OpenFile);
+
+    Menu* submenu = list_menuitem->getSubmenu();
+    if (submenu) {
+        list_menuitem->setSubmenu(NULL);
+        submenu->deferDelete();
+    }
+
+    // Build the menu of recent files
+    submenu = new Menu();
+    list_menuitem->setSubmenu(submenu);
+
+    auto it = App::instance()->recentFiles()->files_begin();
+    auto end = App::instance()->recentFiles()->files_end();
+    if (it != end) {
+        Params params;
+
+        for (; it != end; ++it) {
+            const char* filename = it->c_str();
+            params.set("filename", filename);
+
+            auto menuitem = new AppMenuItem(
+                base::get_file_name(filename).c_str(),
+                cmd_open_file,
+                params);
+            submenu->addChild(menuitem);
+        }
+    }
+    else {
+        auto menuitem = new AppMenuItem("Nothing", NULL, Params());
+        menuitem->setEnabled(false);
+        submenu->addChild(menuitem);
+    }
+}
+
+}

--- a/src/app/recent_files_menu.h
+++ b/src/app/recent_files_menu.h
@@ -1,0 +1,25 @@
+// LibreSprite
+// Copyright (C) 2021 LibreSprite contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 2 as
+// published by the Free Software Foundation.
+
+#pragma once
+
+#include "base/signal.h"
+#include "base/connection.h"
+#include "ui/menu.h"
+
+namespace app {
+
+class RecentFilesMenu {
+public:
+    RecentFilesMenu();
+    void rebuildRecentList();
+
+private:
+    base::ScopedConnection m_recentFilesConn;
+};
+
+}

--- a/src/app/script/script_menu.cpp
+++ b/src/app/script/script_menu.cpp
@@ -1,0 +1,66 @@
+// LibreSprite
+// Copyright (C) 2021 LibreSprite contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 2 as
+// published by the Free Software Foundation.
+
+#include "script_menu.h"
+#include <app/app.h>
+#include <app/app_menus.h>
+#include <app/commands/command.h>
+#include <app/commands/commands.h>
+#include <app/commands/params.h>
+#include <app/file_system.h>
+#include <app/ui/app_menuitem.h>
+#include <app/resource_finder.h>
+#include <base/bind.h>
+#include <base/path.h>
+#include "base/fs.h"
+
+namespace app {
+using namespace ui;
+
+bool ScriptMenu::rebuildScriptsList(Menu* menu)
+{
+  // Update the recent file list menu item
+  if (!menu)
+    return false;
+
+  const WidgetsList& children = menu->children();
+  while (children.size() && children.back()->type() != kSeparatorWidget) {
+    menu->removeChild(children.back());
+  }
+
+  Command* cmd_run_script = CommandsModule::instance()->getCommandByName(CommandId::RunScript);
+  ResourceFinder rf;
+  rf.includeUserDir(base::join_path("scripts", ".").c_str());
+  std::string scriptsDir = rf.getFirstOrCreateDefault();
+
+  if (!base::is_directory(scriptsDir))
+    base::make_directory(scriptsDir);
+
+  FileSystemModule* fs = FileSystemModule::instance();
+  LockFS lock(fs);
+  fs->refresh();
+  IFileItem* item = fs->getFileItemFromPath(scriptsDir);
+  if (item) {
+    Params params;
+    FileItemList list = item->children();
+    for (auto child : list) {
+      if (child->isFolder()) {
+        continue;
+      }
+      std::string fullPath = base::fix_path_separators(child->fileName());
+      params.set("filename", fullPath.c_str());
+      auto menuitem = new AppMenuItem(
+        child->displayName().c_str(),
+        cmd_run_script,
+        params);
+      menu->addChild(menuitem);
+    }
+  }
+  return true;
+}
+
+}

--- a/src/app/script/script_menu.h
+++ b/src/app/script/script_menu.h
@@ -1,0 +1,19 @@
+// LibreSprite
+// Copyright (C) 2021  LibreSprite contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 2 as
+// published by the Free Software Foundation.
+
+#pragma once
+
+#include "ui/menu.h"
+
+namespace app {
+
+class ScriptMenu {
+public:
+    bool rebuildScriptsList(ui::Menu* menu);
+};
+
+}


### PR DESCRIPTION
This PR allows adding new submenus in a way that is more scalable. Instead of having all the logic in app_menus.cpp, it can now be moved out into separate classes (and I've done so for the Recent Files list and the Scripts menu). 
This brings no visual changes.
To allow external classes to manipulate the menu, any submenus/menuitems that have an id attribute in gui.xml are now indexed in a hash map. Being able to lookup things in the menu will be useful for scripts that add their own items in the future.