### PR TITLE
Document scripting api

### DIFF
--- a/src/app/console.cpp
+++ b/src/app/console.cpp
@@ -111,7 +111,7 @@ void Console::printf(const char* format, ...)
   va_list ap;
 
   va_start(ap, format);
-  vsprintf(buf, format, ap);
+  vsnprintf(buf, sizeof(buf), format, ap);
   va_end(ap);
 
   if (!m_withUI || !wid_console) {

--- a/src/app/script/api/app_script.cpp
+++ b/src/app/script/api/app_script.cpp
@@ -6,8 +6,6 @@
 // it under the terms of the GNU General Public License version 2 as
 // published by the Free Software Foundation.
 
-#include "script/engine.h"
-
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -20,6 +18,23 @@
 #include "app/ui/document_view.h"
 #include "doc/site.h"
 
+#include "script/engine.h"
+#include "script/engine_delegate.h"
+#include "script/script_object.h"
+
+#include <sstream>
+
+class DudScriptObject : public script::InternalScriptObject {
+public:
+  void makeLocal() override {}
+
+  void makeGlobal(const std::string& name) override {
+    globalName = name;
+  }
+  std::string globalName;
+};
+static script::InternalScriptObject::Regular<DudScriptObject> dud("DudScriptObject");
+
 namespace app {
 
 class AppScriptObject : public script::ScriptObject {
@@ -28,15 +43,102 @@ public:
   std::vector<inject<ScriptObject>>  m_documents;
 
   AppScriptObject() {
-    addProperty("activeFrameNumber", [this]{return updateSite() ? m_site.frame() : 0;});
-    addProperty("activeLayerNumber", [this]{return updateSite() ? m_site.layerIndex() : 0;});
-    addProperty("activeImage", []{return inject<ScriptObject>{"activeImage"}.get();});
-    addProperty("activeSprite", []{return inject<ScriptObject>{"activeSprite"}.get();});
-    addProperty("activeDocument", []{return inject<ScriptObject>{"activeDocument"}.get();});
-    addProperty("pixelColor", [this]{return m_pixelColor.get();});
-    addProperty("version", []{return script::Value{VERSION};});
+    addProperty("activeFrameNumber", [this]{return updateSite() ? m_site.frame() : 0;})
+        .documentation("Read-only. Returns the number of the currently active animation frame.");
+    addProperty("activeLayerNumber", [this]{return updateSite() ? m_site.layerIndex() : 0;})
+        .documentation("Read-only. Returns the number of the current layer.");
+    addProperty("activeImage", []{return inject<ScriptObject>{"activeImage"}.get();})
+        .documentation("Read-only, can be null. Returns the current layer/frame's image.");
+    addProperty("activeSprite", []{return inject<ScriptObject>{"activeSprite"}.get();})
+        .documentation("Read-only. Returns the currently active Sprite.");
+    addProperty("activeDocument", []{return inject<ScriptObject>{"activeDocument"}.get();})
+        .documentation("Read-only. Returns the currently active Document.");
+    addProperty("pixelColor", [this]{return m_pixelColor.get();})
+        .documentation("Read-only. Returns an object with functions for color conversion");
+    addProperty("version", []{return script::Value{VERSION};})
+        .documentation("Read-only. Returns LibreSprite's current version as a string.");
+    addMethod("documentation", &AppScriptObject::documentation)
+        .documentation("Prints this text.");
     makeGlobal("app");
     init();
+  }
+
+  void documentation() {
+    std::stringstream out;
+    if (!this->get("activeDocument")) {
+      return;
+    }
+
+    auto& internalRegistry = script::InternalScriptObject::getRegistry();
+    auto originalDefault = internalRegistry[""];
+    script::InternalScriptObject::setDefault("DudScriptObject");
+
+    for (auto& entry : script::ScriptObject::getRegistry()) {
+      if (entry.first.empty())
+        continue;
+      inject<ScriptObject> so{entry.first};
+      auto internal = dynamic_cast<DudScriptObject*>(so->getInternalScriptObject());
+      if (!internal)
+        continue;
+
+      out << "# ";
+      if (!internal->globalName.empty())
+        out << "global " << internal->globalName << " ";
+
+      std::string className = entry.first;
+      auto dot = className.rfind("ScriptObject");
+      if (dot != std::string::npos)
+        className.resize(dot);
+
+      out << "[class " << className << "]" << std::endl;
+
+      if (internal->properties.empty()) {
+        out << "## No Properties." << std::endl;
+      } else {
+        out << "## Properties: " << std::endl;
+        for (auto& propEntry : internal->properties) {
+          auto& prop = propEntry.second;
+          out << "   - " << propEntry.first << ": " << prop.doc << std::endl;
+        }
+      }
+
+      out << std::endl;
+
+      if (internal->functions.empty()) {
+        out << "## No Methods." << std::endl;
+      } else {
+        out << "## Methods: " << std::endl;
+        for (auto& funcEntry : internal->functions) {
+          auto& func = funcEntry.second;
+          out << "   - " << funcEntry.first << "(";
+          bool first = true;
+          for (auto& arg : func.argDoc) {
+            if (!first) out << ", ";
+            first = false;
+            out << arg.name;
+          }
+          out << "): " << std::endl;
+
+          for (auto& arg : func.argDoc) {
+            out << "     - " << arg.name << ": " << arg.doc << std::endl;
+          }
+
+          out << "      returns: " << func.resultDoc << std::endl;
+
+          if (!func.doc.empty())
+            out << "      " << func.doc << std::endl;
+
+          out << std::endl;
+        }
+      }
+      out << std::endl << std::endl;
+    }
+
+    std::cout << out.str() << std::endl;
+
+    // inject<script::EngineDelegate>{}->onConsolePrint(out.str().c_str());
+
+    internalRegistry[""] = originalDefault;
   }
 
   bool updateSite() {

--- a/src/app/script/api/app_script.cpp
+++ b/src/app/script/api/app_script.cpp
@@ -44,21 +44,29 @@ public:
 
   AppScriptObject() {
     addProperty("activeFrameNumber", [this]{return updateSite() ? m_site.frame() : 0;})
-        .documentation("Read-only. Returns the number of the currently active animation frame.");
+      .doc("read-only. Returns the number of the currently active animation frame.");
+
     addProperty("activeLayerNumber", [this]{return updateSite() ? m_site.layerIndex() : 0;})
-        .documentation("Read-only. Returns the number of the current layer.");
+      .doc("read-only. Returns the number of the current layer.");
+
     addProperty("activeImage", []{return inject<ScriptObject>{"activeImage"}.get();})
-        .documentation("Read-only, can be null. Returns the current layer/frame's image.");
+      .doc("read-only, can be null. Returns the current layer/frame's image.");
+
     addProperty("activeSprite", []{return inject<ScriptObject>{"activeSprite"}.get();})
-        .documentation("Read-only. Returns the currently active Sprite.");
+      .doc("read-only. Returns the currently active Sprite.");
+
     addProperty("activeDocument", []{return inject<ScriptObject>{"activeDocument"}.get();})
-        .documentation("Read-only. Returns the currently active Document.");
+      .doc("read-only. Returns the currently active Document.");
+
     addProperty("pixelColor", [this]{return m_pixelColor.get();})
-        .documentation("Read-only. Returns an object with functions for color conversion");
+      .doc("read-only. Returns an object with functions for color conversion.");
+
     addProperty("version", []{return script::Value{VERSION};})
-        .documentation("Read-only. Returns LibreSprite's current version as a string.");
+      .doc("read-only. Returns LibreSprite's current version as a string.");
+
     addMethod("documentation", &AppScriptObject::documentation)
-        .documentation("Prints this text.");
+      .doc("prints this text.");
+
     makeGlobal("app");
     init();
   }
@@ -98,7 +106,7 @@ public:
         out << "## Properties: " << std::endl;
         for (auto& propEntry : internal->properties) {
           auto& prop = propEntry.second;
-          out << "   - " << propEntry.first << ": " << prop.doc << std::endl;
+          out << "   - `" << propEntry.first << "`: " << prop.docStr << std::endl;
         }
       }
 
@@ -110,23 +118,23 @@ public:
         out << "## Methods: " << std::endl;
         for (auto& funcEntry : internal->functions) {
           auto& func = funcEntry.second;
-          out << "   - " << funcEntry.first << "(";
+          out << "   - `" << funcEntry.first << "(";
           bool first = true;
-          for (auto& arg : func.argDoc) {
+          for (auto& arg : func.docArgs) {
             if (!first) out << ", ";
             first = false;
             out << arg.name;
           }
-          out << "): " << std::endl;
+          out << ")`: " << std::endl;
 
-          for (auto& arg : func.argDoc) {
-            out << "     - " << arg.name << ": " << arg.doc << std::endl;
+          for (auto& arg : func.docArgs) {
+            out << "     - " << arg.name << ": " << arg.docStr << std::endl;
           }
 
-          out << "      returns: " << func.resultDoc << std::endl;
+          out << "      returns: " << func.docReturnsStr << std::endl;
 
-          if (!func.doc.empty())
-            out << "      " << func.doc << std::endl;
+          if (!func.docStr.empty())
+            out << "      " << func.docStr << std::endl;
 
           out << std::endl;
         }

--- a/src/app/script/api/image_script.cpp
+++ b/src/app/script/api/image_script.cpp
@@ -11,16 +11,30 @@
 class ImageScriptObject : public script::ScriptObject {
 public:
   ImageScriptObject() {
-    addProperty("width", [this]{return m_image->width();});
-    addProperty("height", [this]{return m_image->height();});
-    addProperty("format", [this]{return (int) m_image->pixelFormat();});
-    addFunction("getPixel", [this](int x, int y){return m_image->getPixel(x, y);});
-    addMethod("putPixel", &ImageScriptObject::putPixel);
-    addMethod("clear", &ImageScriptObject::clear);
+    addProperty("width", [this]{return m_image->width();})
+      .documentation("Read-only. The width of the image");
+    addProperty("height", [this]{return m_image->height();})
+      .documentation("Read-only. The height of the image");
+    addProperty("format", [this]{return (int) m_image->pixelFormat();})
+      .documentation("Read-only. The PixelFormat of the image");
+    addFunction("getPixel", [this](int x, int y){return m_image->getPixel(x, y);})
+      .arg("x", "Integer")
+      .arg("y", "Integer")
+      .returns("A color value")
+      .documentation("Reads a color from the given coordinate of the image.");
+    addMethod("putPixel", &ImageScriptObject::putPixel)
+      .arg("x", "Integer")
+      .arg("y", "Integer")
+      .arg("color", "A 32-bit color in 8888 RGBA format")
+      .documentation("Writes the color onto the image at the the given coordinate.");
+    addMethod("clear", &ImageScriptObject::clear)
+      .arg("color", "A 32-bit color in 8888 RGBA format")
+      .documentation("Clears the image with the specified color");
   }
 
   void putPixel(int x, int y, int color) {
-    m_image->putPixel(x, y, color);
+    if (unsigned(x) < m_image->width() && unsigned(y) < m_image->height())
+      m_image->putPixel(x, y, color);
   }
 
   void clear(int color) {

--- a/src/app/script/api/image_script.cpp
+++ b/src/app/script/api/image_script.cpp
@@ -12,24 +12,29 @@ class ImageScriptObject : public script::ScriptObject {
 public:
   ImageScriptObject() {
     addProperty("width", [this]{return m_image->width();})
-      .documentation("Read-only. The width of the image");
+      .doc("read-only. The width of the image.");
+
     addProperty("height", [this]{return m_image->height();})
-      .documentation("Read-only. The height of the image");
+      .doc("read-only. The height of the image.");
+
     addProperty("format", [this]{return (int) m_image->pixelFormat();})
-      .documentation("Read-only. The PixelFormat of the image");
+      .doc("read-only. The PixelFormat of the image.");
+
     addFunction("getPixel", [this](int x, int y){return m_image->getPixel(x, y);})
-      .arg("x", "Integer")
-      .arg("y", "Integer")
-      .returns("A color value")
-      .documentation("Reads a color from the given coordinate of the image.");
+      .doc("reads a color from the given coordinate of the image.")
+      .docArg("x", "integer")
+      .docArg("y", "integer")
+      .docReturns("a color value");
+
     addMethod("putPixel", &ImageScriptObject::putPixel)
-      .arg("x", "Integer")
-      .arg("y", "Integer")
-      .arg("color", "A 32-bit color in 8888 RGBA format")
-      .documentation("Writes the color onto the image at the the given coordinate.");
+      .doc("writes the color onto the image at the the given coordinate.")
+      .docArg("x", "integer")
+      .docArg("y", "integer")
+      .docArg("color", "a 32-bit color in 8888 RGBA format");
+
     addMethod("clear", &ImageScriptObject::clear)
-      .arg("color", "A 32-bit color in 8888 RGBA format")
-      .documentation("Clears the image with the specified color");
+      .doc("clears the image with the specified color.")
+      .docArg("color", "a 32-bit color in 8888 RGBA format");
   }
 
   void putPixel(int x, int y, int color) {

--- a/src/app/script/api/layer_script.cpp
+++ b/src/app/script/api/layer_script.cpp
@@ -16,29 +16,42 @@ public:
                 [this](const std::string& name){
                   m_layer->setName(name);
                   return name;
-                });
-    addProperty("isImage", [this]{return m_layer->isImage();});
-    addProperty("isBackground", [this]{return m_layer->isBackground();});
-    addProperty("isTransparent", [this]{return m_layer->isTransparent();});
+                })
+      .documentation("Read+Write. The name of the layer.");
+    addProperty("isImage", [this]{return m_layer->isImage();})
+      .documentation("Read-only. Returns true if the layer is an image, false if it is a folder.");
+    addProperty("isBackground", [this]{return m_layer->isBackground();})
+      .documentation("Read-only. Returns true if the layer is a background layer.");
+    addProperty("isTransparent", [this]{return m_layer->isTransparent();})
+      .documentation("Read-only. Returns true if the layer is a non-background image layer");
     addProperty("isVisible",
                 [this]{return m_layer->isVisible();},
                 [this](bool i){
                   m_layer->setVisible(i);
                   return i;
-                });
+                })
+      .documentation("Read+Write. Gets/sets whether the layer is visible or not.");
     addProperty("isEditable",
                 [this]{return m_layer->isEditable();},
                 [this](bool i){
                   m_layer->setEditable(i);
                   return i;
-                });
-    addProperty("isMovable", [this]{return m_layer->isMovable();});
-    addProperty("isContinuous", [this]{return m_layer->isContinuous();});
-    addProperty("flags", [this]{return (int) m_layer->flags();});
+                })
+      .documentation("Read+Write. Gets/sets whether the layer is editable (unlocked) or not (locked).");
+    addProperty("isMovable", [this]{return m_layer->isMovable();})
+      .documentation("Read-only. Returns true if the layer is movable.");
+    addProperty("isContinuous", [this]{return m_layer->isContinuous();})
+      .documentation("Read-only. Prefer to link cels when the user copy them.");
+    addProperty("flags", [this]{return (int) m_layer->flags();})
+      .documentation("Read-only. Returns all flags OR'd together as an int");
     addProperty("celCount", [this]{
       return m_layer->isImage() ? static_cast<doc::LayerImage*>(m_layer)->getCelsCount() : 0;
-    });
-    addMethod("cel", &LayerScriptObject::cel);
+    })
+      .documentation("Read-only. Returns the number of cels.");
+    addMethod("cel", &LayerScriptObject::cel)
+      .arg("index", "The number of the Cel")
+      .returns("A Cel object or null if an invalid index is passed")
+      .documentation("Retrieves a Cel");
   }
 
   ScriptObject* cel(int i){

--- a/src/app/script/api/layer_script.cpp
+++ b/src/app/script/api/layer_script.cpp
@@ -17,41 +17,51 @@ public:
                   m_layer->setName(name);
                   return name;
                 })
-      .documentation("Read+Write. The name of the layer.");
+      .doc("read+write. The name of the layer.");
+
     addProperty("isImage", [this]{return m_layer->isImage();})
-      .documentation("Read-only. Returns true if the layer is an image, false if it is a folder.");
+      .doc("read-only. Returns true if the layer is an image, false if it is a folder.");
+
     addProperty("isBackground", [this]{return m_layer->isBackground();})
-      .documentation("Read-only. Returns true if the layer is a background layer.");
+      .doc("read-only. Returns true if the layer is a background layer.");
+
     addProperty("isTransparent", [this]{return m_layer->isTransparent();})
-      .documentation("Read-only. Returns true if the layer is a non-background image layer");
+      .doc("read-only. Returns true if the layer is a non-background image layer.");
+
     addProperty("isVisible",
                 [this]{return m_layer->isVisible();},
                 [this](bool i){
                   m_layer->setVisible(i);
                   return i;
                 })
-      .documentation("Read+Write. Gets/sets whether the layer is visible or not.");
+      .doc("read+write. Gets/sets whether the layer is visible or not.");
+
     addProperty("isEditable",
                 [this]{return m_layer->isEditable();},
                 [this](bool i){
                   m_layer->setEditable(i);
                   return i;
                 })
-      .documentation("Read+Write. Gets/sets whether the layer is editable (unlocked) or not (locked).");
+      .doc("read+write. Gets/sets whether the layer is editable (unlocked) or not (locked).");
+
     addProperty("isMovable", [this]{return m_layer->isMovable();})
-      .documentation("Read-only. Returns true if the layer is movable.");
+      .doc("read-only. Returns true if the layer is movable.");
+
     addProperty("isContinuous", [this]{return m_layer->isContinuous();})
-      .documentation("Read-only. Prefer to link cels when the user copy them.");
+      .doc("read-only. Prefer to link cels when the user copies them.");
+
     addProperty("flags", [this]{return (int) m_layer->flags();})
-      .documentation("Read-only. Returns all flags OR'd together as an int");
+      .doc("read-only. Returns all flags OR'd together as an int");
+
     addProperty("celCount", [this]{
       return m_layer->isImage() ? static_cast<doc::LayerImage*>(m_layer)->getCelsCount() : 0;
     })
-      .documentation("Read-only. Returns the number of cels.");
+      .doc("read-only. Returns the number of cels.");
+
     addMethod("cel", &LayerScriptObject::cel)
-      .arg("index", "The number of the Cel")
-      .returns("A Cel object or null if an invalid index is passed")
-      .documentation("Retrieves a Cel");
+      .doc("retrieves a Cel")
+      .docArg("index", "The number of the Cel")
+      .docReturns("A Cel object or null if an invalid index is passed");
   }
 
   ScriptObject* cel(int i){

--- a/src/app/script/api/pixelcolor_script.cpp
+++ b/src/app/script/api/pixelcolor_script.cpp
@@ -12,41 +12,49 @@ class PixelColorScriptObject : public script::ScriptObject {
 public:
   PixelColorScriptObject() {
     addFunction("rgba", doc::rgba)
-      .arg("r", "Red, 0-255")
-      .arg("g", "Green, 0-255")
-      .arg("b", "Blue, 0-255")
-      .arg("a", "Alpha (opacity), 0-255")
-      .returns("A 32-bit color in 8888 RGBA format")
+      .doc("Converts R, G, B, A values into a single 32-bit RGBA color.")
+      .docArg("r", "red, 0-255.")
+      .docArg("g", "green, 0-255.")
+      .docArg("b", "blue, 0-255.")
+      .docArg("a", "alpha (opacity), 0-255.")
+      .docReturns("A 32-bit color in 8888 RGBA format.")
       .setDefault(0, 0, 0, 255);
+
     addFunction("rgbaR", doc::rgba_getr)
-      .arg("color", "A 32-bit color in 8888 RGBA format")
-      .returns("The red component of the color")
-      .documentation("Extracts the red channel from a 32-bit color");
+      .doc("Extracts the red channel from a 32-bit color")
+      .docArg("color", "A 32-bit color in 8888 RGBA format")
+      .docReturns("The red component of the color");
+
     addFunction("rgbaG", doc::rgba_getg)
-      .arg("color", "A 32-bit color in 8888 RGBA format")
-      .returns("The green component of the color")
-      .documentation("Extracts the green channel from a 32-bit color");
+      .doc("Extracts the green channel from a 32-bit color")
+      .docArg("color", "A 32-bit color in 8888 RGBA format")
+      .docReturns("The green component of the color");
+
     addFunction("rgbaB", doc::rgba_getb)
-      .arg("color", "A 32-bit color in 8888 RGBA format")
-      .returns("The blue component of the color")
-      .documentation("Extracts the blue channel from a 32-bit color");
+      .doc("Extracts the blue channel from a 32-bit color")
+      .docArg("color", "A 32-bit color in 8888 RGBA format")
+      .docReturns("The blue component of the color");
+
     addFunction("rgbaA", doc::rgba_geta)
-      .arg("color", "A 32-bit color in 8888 RGBA format")
-      .returns("The alpha component of the color")
-      .documentation("Extracts the alpha channel from a 32-bit color");
+      .doc("Extracts the alpha channel from a 32-bit color")
+      .docArg("color", "A 32-bit color in 8888 RGBA format")
+      .docReturns("The alpha component of the color");
+
     addFunction("graya", doc::graya)
-      .arg("gray", "The luminance of color")
-      .arg("alpha", "The alpha (opacity) of the color)")
-      .returns("The color with the given luminance/opacity")
+      .docArg("gray", "The luminance of color")
+      .docArg("alpha", "The alpha (opacity) of the color)")
+      .docReturns("The color with the given luminance/opacity")
       .setDefault(0, 255);
+
     addFunction("grayaV", doc::graya_getv)
-      .arg("color", "A 32-bit color in 888 RGBA format")
-      .returns("The luminance Value of the color")
-      .documentation("Extracts the luminance from a 32-bit color");
+      .doc("Extracts the luminance from a 32-bit color")
+      .docArg("color", "A 32-bit color in 888 RGBA format")
+      .docReturns("The luminance Value of the color");
+
     addFunction("grayaA", doc::graya_geta)
-      .arg("color", "A 32-bit color in 888 RGBA format")
-      .returns("The alpha component of the color")
-      .documentation("Extracts the alpha (opacity) from a 32-bit color");
+      .doc("Extracts the alpha (opacity) from a 32-bit color")
+      .docArg("color", "A 32-bit color in 888 RGBA format")
+      .docReturns("The alpha component of the color");
   }
 };
 

--- a/src/app/script/api/pixelcolor_script.cpp
+++ b/src/app/script/api/pixelcolor_script.cpp
@@ -11,14 +11,42 @@
 class PixelColorScriptObject : public script::ScriptObject {
 public:
   PixelColorScriptObject() {
-    addFunction("rgba", doc::rgba).setDefault(0, 0, 0, 255);
-    addFunction("rgbaR", doc::rgba_getr);
-    addFunction("rgbaG", doc::rgba_getg);
-    addFunction("rgbaB", doc::rgba_getb);
-    addFunction("rgbaA", doc::rgba_geta);
-    addFunction("graya", doc::graya).setDefault(0, 255);
-    addFunction("grayaV", doc::graya_getv);
-    addFunction("grayaA", doc::graya_geta);
+    addFunction("rgba", doc::rgba)
+      .arg("r", "Red, 0-255")
+      .arg("g", "Green, 0-255")
+      .arg("b", "Blue, 0-255")
+      .arg("a", "Alpha (opacity), 0-255")
+      .returns("A 32-bit color in 8888 RGBA format")
+      .setDefault(0, 0, 0, 255);
+    addFunction("rgbaR", doc::rgba_getr)
+      .arg("color", "A 32-bit color in 8888 RGBA format")
+      .returns("The red component of the color")
+      .documentation("Extracts the red channel from a 32-bit color");
+    addFunction("rgbaG", doc::rgba_getg)
+      .arg("color", "A 32-bit color in 8888 RGBA format")
+      .returns("The green component of the color")
+      .documentation("Extracts the green channel from a 32-bit color");
+    addFunction("rgbaB", doc::rgba_getb)
+      .arg("color", "A 32-bit color in 8888 RGBA format")
+      .returns("The blue component of the color")
+      .documentation("Extracts the blue channel from a 32-bit color");
+    addFunction("rgbaA", doc::rgba_geta)
+      .arg("color", "A 32-bit color in 8888 RGBA format")
+      .returns("The alpha component of the color")
+      .documentation("Extracts the alpha channel from a 32-bit color");
+    addFunction("graya", doc::graya)
+      .arg("gray", "The luminance of color")
+      .arg("alpha", "The alpha (opacity) of the color)")
+      .returns("The color with the given luminance/opacity")
+      .setDefault(0, 255);
+    addFunction("grayaV", doc::graya_getv)
+      .arg("color", "A 32-bit color in 888 RGBA format")
+      .returns("The luminance Value of the color")
+      .documentation("Extracts the luminance from a 32-bit color");
+    addFunction("grayaA", doc::graya_geta)
+      .arg("color", "A 32-bit color in 888 RGBA format")
+      .returns("The alpha component of the color")
+      .documentation("Extracts the alpha (opacity) from a 32-bit color");
   }
 };
 

--- a/src/app/script/api/sprite_script.cpp
+++ b/src/app/script/api/sprite_script.cpp
@@ -26,29 +26,53 @@ class SpriteScriptObject : public script::ScriptObject {
 
 public:
   SpriteScriptObject() : m_sprite{doc()->sprite()} {
-    addProperty("layerCount", [this]{return (int) m_sprite->countLayers();});
-    addProperty("filename", [this]{return doc()->filename();});
+    addProperty("layerCount", [this]{return (int) m_sprite->countLayers();})
+      .documentation("Read-only. Returns the amount of layers in the sprite.");
+    addProperty("filename", [this]{return doc()->filename();})
+      .documentation("Read-only. Returns the file name of the sprite.");
     addProperty("width",
                 [this]{return m_sprite->width();},
                 [this](int width){
                   transaction().execute(new app::cmd::SetSpriteSize(m_sprite, width, m_sprite->height()));
                   return 0;
-                });
+                })
+      .documentation("Read+Write. Returns and sets the width of the sprite.");
     addProperty("height",
                 [this]{return m_sprite->height();},
                 [this](int height){
                   transaction().execute(new app::cmd::SetSpriteSize(m_sprite, m_sprite->width(), height));
                   return 0;
-                });
-    addProperty("colorMode", [this]{ return m_sprite->pixelFormat();});
-    addProperty("selection", [this]{ return this; });
-    addMethod("layer", &SpriteScriptObject::layer);
-    addMethod("commit", &SpriteScriptObject::commit);
-    addMethod("resize", &SpriteScriptObject::resize);
-    addMethod("crop", &SpriteScriptObject::crop);
-    addMethod("save", &SpriteScriptObject::save);
-    addMethod("saveAs", &SpriteScriptObject::saveAs);
-    addMethod("loadPalette", &SpriteScriptObject::loadPalette);
+                })
+      .documentation("Read+Write. Returns and sets the height of the sprite.");
+    addProperty("colorMode", [this]{ return m_sprite->pixelFormat();})
+      .documentation("Read-only. Returns the sprite's ColorMode.");
+    addProperty("selection", [this]{ return this; })
+      .documentation("Placeholder. Do not use.");
+    addMethod("layer", &SpriteScriptObject::layer)
+      .arg("layerNumber", "The number of they layer, starting with zero from the bottom.")
+      .returns("A Layer object or null if invalid.")
+      .documentation("Allows you to access a given layer.");
+    addMethod("commit", &SpriteScriptObject::commit)
+      .documentation("Commits the current transaction.");
+    addMethod("resize", &SpriteScriptObject::resize)
+      .arg("width", "The new width.")
+      .arg("height", "The new height.")
+      .documentation("Resizes the sprite.");
+    addMethod("crop", &SpriteScriptObject::crop)
+      .arg("x", "The left-most edge of the crop.")
+      .arg("y", "The top-most edge of the crop.")
+      .arg("width", "The width of the cropped area.")
+      .arg("height", "The height of the cropped area.")
+      .documentation("Crops the sprite to the specified dimensions");
+    addMethod("save", &SpriteScriptObject::save)
+      .documentation("Saves the sprite");
+    addMethod("saveAs", &SpriteScriptObject::saveAs)
+      .arg("fileName", "String. The new name of the file")
+      .arg("asCopy", "If true, the file is saved as a copy. Requires fileName to be specified.")
+      .documentation("Saves the sprite");
+    addMethod("loadPalette", &SpriteScriptObject::loadPalette)
+      .arg("fileName", "The name of the palette file to load")
+      .documentation("Loads a palette file");
   }
 
   ~SpriteScriptObject() {

--- a/src/app/script/api/sprite_script.cpp
+++ b/src/app/script/api/sprite_script.cpp
@@ -27,52 +27,64 @@ class SpriteScriptObject : public script::ScriptObject {
 public:
   SpriteScriptObject() : m_sprite{doc()->sprite()} {
     addProperty("layerCount", [this]{return (int) m_sprite->countLayers();})
-      .documentation("Read-only. Returns the amount of layers in the sprite.");
+      .doc("read-only. Returns the amount of layers in the sprite.");
+
     addProperty("filename", [this]{return doc()->filename();})
-      .documentation("Read-only. Returns the file name of the sprite.");
+      .doc("read-only. Returns the file name of the sprite.");
+
     addProperty("width",
                 [this]{return m_sprite->width();},
                 [this](int width){
                   transaction().execute(new app::cmd::SetSpriteSize(m_sprite, width, m_sprite->height()));
                   return 0;
                 })
-      .documentation("Read+Write. Returns and sets the width of the sprite.");
+      .doc("read+write. Returns and sets the width of the sprite.");
+
     addProperty("height",
                 [this]{return m_sprite->height();},
                 [this](int height){
                   transaction().execute(new app::cmd::SetSpriteSize(m_sprite, m_sprite->width(), height));
                   return 0;
                 })
-      .documentation("Read+Write. Returns and sets the height of the sprite.");
+      .doc("read+write. Returns and sets the height of the sprite.");
+
     addProperty("colorMode", [this]{ return m_sprite->pixelFormat();})
-      .documentation("Read-only. Returns the sprite's ColorMode.");
+      .doc("read-only. Returns the sprite's ColorMode.");
+
     addProperty("selection", [this]{ return this; })
-      .documentation("Placeholder. Do not use.");
+      .doc("placeholder. Do not use.");
+
     addMethod("layer", &SpriteScriptObject::layer)
-      .arg("layerNumber", "The number of they layer, starting with zero from the bottom.")
-      .returns("A Layer object or null if invalid.")
-      .documentation("Allows you to access a given layer.");
+      .doc("allows you to access a given layer.")
+      .docArg("layerNumber", "The number of they layer, starting with zero from the bottom.")
+      .docReturns("a Layer object or null if invalid.");
+
     addMethod("commit", &SpriteScriptObject::commit)
-      .documentation("Commits the current transaction.");
+      .doc("commits the current transaction.");
+
     addMethod("resize", &SpriteScriptObject::resize)
-      .arg("width", "The new width.")
-      .arg("height", "The new height.")
-      .documentation("Resizes the sprite.");
+      .doc("resizes the sprite.")
+      .docArg("width", "The new width.")
+      .docArg("height", "The new height.");
+
     addMethod("crop", &SpriteScriptObject::crop)
-      .arg("x", "The left-most edge of the crop.")
-      .arg("y", "The top-most edge of the crop.")
-      .arg("width", "The width of the cropped area.")
-      .arg("height", "The height of the cropped area.")
-      .documentation("Crops the sprite to the specified dimensions");
+      .doc("crops the sprite to the specified dimensions.")
+      .docArg("x", "The left-most edge of the crop.")
+      .docArg("y", "The top-most edge of the crop.")
+      .docArg("width", "The width of the cropped area.")
+      .docArg("height", "The height of the cropped area.");
+
     addMethod("save", &SpriteScriptObject::save)
-      .documentation("Saves the sprite");
+      .doc("saves the sprite.");
+
     addMethod("saveAs", &SpriteScriptObject::saveAs)
-      .arg("fileName", "String. The new name of the file")
-      .arg("asCopy", "If true, the file is saved as a copy. Requires fileName to be specified.")
-      .documentation("Saves the sprite");
+      .doc("saves the sprite.")
+      .docArg("fileName", "String. The new name of the file")
+      .docArg("asCopy", "If true, the file is saved as a copy. Requires fileName to be specified.");
+
     addMethod("loadPalette", &SpriteScriptObject::loadPalette)
-      .arg("fileName", "The name of the palette file to load")
-      .documentation("Loads a palette file");
+      .doc("loads a palette file.")
+      .docArg("fileName", "The name of the palette file to load");
   }
 
   ~SpriteScriptObject() {

--- a/src/script/script_object.h
+++ b/src/script/script_object.h
@@ -15,6 +15,44 @@ namespace script {
   struct ObjectProperty {
     Function getter;
     Function setter;
+    std::string doc;
+
+    ObjectProperty& documentation(const std::string& str) {
+      doc = str;
+      return *this;
+    }
+  };
+
+  struct DocumentedFunction : public Function {
+    std::string doc;
+
+    struct ArgDoc {
+      std::string name;
+      std::string doc;
+    };
+
+    std::vector<ArgDoc> argDoc;
+
+    std::string resultDoc = "Nothing";
+
+    DocumentedFunction(const Function& other) : Function(other) {}
+
+    DocumentedFunction(Function&& other) : Function(std::move(other)) {}
+
+    DocumentedFunction& documentation(const std::string& str) {
+      doc = str;
+      return *this;
+    }
+
+    DocumentedFunction& arg(const std::string& arg, const std::string& doc) {
+      argDoc.emplace_back(ArgDoc{arg, doc});
+      return *this;
+    }
+
+    DocumentedFunction& returns(const std::string& doc) {
+      resultDoc = doc;
+      return *this;
+    }
   };
 
   class InternalScriptObject : public Injectable<InternalScriptObject> {
@@ -22,19 +60,20 @@ namespace script {
     virtual void makeGlobal(const std::string& name) = 0;
     virtual void makeLocal() = 0;
 
-    virtual void addProperty(const std::string& name, const Function& get, const Function& set) {
+    virtual ObjectProperty& addProperty(const std::string& name, const Function& get, const Function& set) {
       auto& prop = properties[name];
       prop.getter = get;
       prop.setter = set;
+      return prop;
     }
 
-    virtual Function& addFunction(const std::string& name, const Function& func) {
+    virtual DocumentedFunction& addFunction(const std::string& name, const Function& func) {
       return functions.emplace(name, func).first->second;
     }
 
     inject<script::Engine> m_engine;
     std::unordered_map<std::string, ObjectProperty> properties;
-    std::unordered_map<std::string, Function> functions;
+    std::unordered_map<std::string, DocumentedFunction> functions;
   };
 
   class ScriptObject : public Injectable<ScriptObject> {
@@ -81,23 +120,23 @@ namespace script {
       m_internal->makeGlobal(name);
     }
 
-    void addProperty(const std::string& name, const Function& get = []{return Value{};}, const Function &set = [](const Value&){return Value{};}) {
-      m_internal->addProperty(name, get, set);
+    ObjectProperty& addProperty(const std::string& name, const Function& get = []{return Value{};}, const Function &set = [](const Value&){return Value{};}) {
+      return m_internal->addProperty(name, get, set);
     }
 
-    Function& addFunction(const std::string& name, const Function& func) {
+    DocumentedFunction& addFunction(const std::string& name, const Function& func) {
       return m_internal->addFunction(name, func);
     }
 
     template<typename Class, typename Ret, typename ... Args>
-    Function& addMethod(const std::string& name, Class* instance, Ret(Class::*method)(Args...)) {
+    DocumentedFunction& addMethod(const std::string& name, Class* instance, Ret(Class::*method)(Args...)) {
       return addFunction(name, [=](Args ... args){
         return (instance->*method)(std::forward<Args>(args)...);
       });
     }
 
     template<typename Class, typename ... Args>
-    Function& addMethod(const std::string& name, Class* instance, void(Class::*method)(Args...)) {
+    DocumentedFunction& addMethod(const std::string& name, Class* instance, void(Class::*method)(Args...)) {
       return addFunction(name, [=](Args ... args){
         (instance->*method)(std::forward<Args>(args)...);
         return Value{};
@@ -105,14 +144,14 @@ namespace script {
     }
 
     template<typename Class, typename Ret, typename ... Args>
-    Function& addMethod(const std::string& name, Ret(Class::*method)(Args...)) {
+    DocumentedFunction& addMethod(const std::string& name, Ret(Class::*method)(Args...)) {
       return addFunction(name, [=](Args ... args){
         return (static_cast<Class*>(this)->*method)(std::forward<Args>(args)...);
       });
     }
 
     template<typename Class, typename ... Args>
-    Function& addMethod(const std::string& name, void(Class::*method)(Args...)) {
+    DocumentedFunction& addMethod(const std::string& name, void(Class::*method)(Args...)) {
       return addFunction(name, [=](Args ... args){
         (static_cast<Class*>(this)->*method)(std::forward<Args>(args)...);
         return Value{};

--- a/src/script/script_object.h
+++ b/src/script/script_object.h
@@ -15,42 +15,39 @@ namespace script {
   struct ObjectProperty {
     Function getter;
     Function setter;
-    std::string doc;
+    std::string docStr;
 
-    ObjectProperty& documentation(const std::string& str) {
-      doc = str;
+    ObjectProperty& doc(const std::string& str) {
+      docStr = str;
       return *this;
     }
   };
 
   struct DocumentedFunction : public Function {
-    std::string doc;
-
-    struct ArgDoc {
+    struct DocArg {
       std::string name;
-      std::string doc;
+      std::string docStr;
     };
-
-    std::vector<ArgDoc> argDoc;
-
-    std::string resultDoc = "Nothing";
+    std::string docStr;
+    std::vector<DocArg> docArgs;
+    std::string docReturnsStr = "Nothing";
 
     DocumentedFunction(const Function& other) : Function(other) {}
 
     DocumentedFunction(Function&& other) : Function(std::move(other)) {}
 
-    DocumentedFunction& documentation(const std::string& str) {
-      doc = str;
+    DocumentedFunction& doc(const std::string& str) {
+      docStr = str;
       return *this;
     }
 
-    DocumentedFunction& arg(const std::string& arg, const std::string& doc) {
-      argDoc.emplace_back(ArgDoc{arg, doc});
+    DocumentedFunction& docArg(const std::string& arg, const std::string& doc) {
+      docArgs.emplace_back(DocArg{arg, doc});
       return *this;
     }
 
-    DocumentedFunction& returns(const std::string& doc) {
-      resultDoc = doc;
+    DocumentedFunction& docReturns(const std::string& doc) {
+      docReturnsStr = doc;
       return *this;
     }
   };


### PR DESCRIPTION
Partial documentation support for the scripting API. Since the API itself is not yet set in stone, this should
not be seen as final. I am sending it as-is so that we can discuss the formatting/style and in hopes that it 
may be of some use since it's better than nothing.

To see the documentation, open an image and run the following script:
`app.documentation()`
It should print everything to the terminal, not to a GUI dialog.