### PR TITLE
Split PaletteListBox into two classes

### DIFF
--- a/src/app/ui/palette_listbox.cpp
+++ b/src/app/ui/palette_listbox.cpp
@@ -30,14 +30,13 @@ using namespace skin;
 
 class PaletteListItem : public ListItem {
 public:
-  PaletteListItem(PaletteResource* palResource)
-    : ListItem(palResource->name()), m_palResource(palResource) {
-  }
+  PaletteListItem(PaletteResource* palResource) :
+    ListItem(palResource->name()), m_palResource(palResource) {}
 
-    PaletteListItem(std::unique_ptr<doc::Palette>&& palette, const std::string& name) :
-        PaletteListItem(new PaletteResource(palette.get(), name)) {
-        m_palette = std::move(palette);
-    }
+  PaletteListItem(std::unique_ptr<doc::Palette>&& palette, const std::string& name) :
+    PaletteListItem(new PaletteResource(palette.get(), name)) {
+    m_palette = std::move(palette);
+  }
 
   PaletteResource* paletteResource() const {
     return m_palResource.get();

--- a/src/app/ui/palette_listbox.cpp
+++ b/src/app/ui/palette_listbox.cpp
@@ -34,8 +34,13 @@ public:
     : ListItem(palResource->name()), m_palResource(palResource) {
   }
 
+    PaletteListItem(std::unique_ptr<doc::Palette>&& palette, const std::string& name) :
+        PaletteListItem(new PaletteResource(palette.get(), name)) {
+        m_palette = std::move(palette);
+    }
+
   PaletteResource* paletteResource() const {
-    return m_palResource;
+    return m_palResource.get();
   }
 
 protected:
@@ -108,7 +113,8 @@ protected:
   }
 
 private:
-  base::UniquePtr<PaletteResource> m_palResource;
+  std::unique_ptr<PaletteResource> m_palResource;
+  std::unique_ptr<doc::Palette> m_palette;
 };
 
 class PaletteListBox::LoadingItem : public ListItem {
@@ -135,90 +141,100 @@ private:
   int m_state;
 };
 
-PaletteListBox::PaletteListBox()
-  : m_resourcesLoader(new ResourcesLoader(new PalettesLoaderDelegate))
-  , m_resourcesTimer(100)
-  , m_loadingItem(NULL)
-{
-  m_resourcesTimer.Tick.connect(base::Bind<void>(&PaletteListBox::onTick, this));
-}
-
-doc::Palette* PaletteListBox::selectedPalette()
-{
+PaletteResource* PaletteListBox::selectedPaletteResource() {
   if (PaletteListItem* listItem = dynamic_cast<PaletteListItem*>(getSelectedChild()))
-    return listItem->paletteResource()->palette();
+    return listItem->paletteResource();
   else
-    return NULL;
+    return nullptr;
 }
 
-bool PaletteListBox::onProcessMessage(ui::Message* msg)
-{
-  switch (msg->type()) {
-
-    case kOpenMessage: {
-      m_resourcesTimer.start();
-      break;
-    }
-
-  }
-  return ListBox::onProcessMessage(msg);
+doc::Palette* PaletteListBox::selectedPalette() {
+  auto resource = selectedPaletteResource();
+  return resource ? resource->palette() : nullptr;
 }
 
-void PaletteListBox::onChange()
-{
-  doc::Palette* palette = selectedPalette();
+std::string PaletteListBox::selectedPaletteName() {
+  auto resource = selectedPaletteResource();
+  return resource ? resource->name() : "";
+}
+
+void PaletteListBox::onChange() {
+  auto palette = selectedPalette();
   if (palette)
     PalChange(palette);
 }
 
-void PaletteListBox::onTick()
-{
+void PaletteListBox::setLoading(bool isLoading) {
+  if (isLoading) {
+    if (!m_loadingItem) {
+      m_loadingItem = new LoadingItem;
+      addChild(m_loadingItem);
+    }
+    m_loadingItem->makeProgress();
+  } else {
+    if (m_loadingItem) {
+      removeChild(m_loadingItem);
+      delete m_loadingItem;
+      m_loadingItem = nullptr;
+      invalidate();
+    }
+  }
+}
+
+void PaletteListBox::addPalette(doc::Palette *palette, const std::string& name) {
+  int hasLoading = !!m_loadingItem;
+  insertChild(getItemsCount()-hasLoading, new PaletteListItem(std::unique_ptr<doc::Palette>(palette), name));
+  layout();
+  View* view = View::getView(this);
+  if (view)
+    view->updateView();
+}
+
+void PaletteListBox::addPalette(PaletteResource *resource) {
+  int hasLoading = !!m_loadingItem;
+  insertChild(getItemsCount()-hasLoading, new PaletteListItem(resource));
+  layout();
+  View* view = View::getView(this);
+  if (view)
+    view->updateView();
+}
+
+PaletteFileListBox::PaletteFileListBox() : m_resourcesLoader(new ResourcesLoader(new PalettesLoaderDelegate)),
+                                           m_resourcesTimer(100) {
+  m_resourcesTimer.Tick.connect(base::Bind<void>(&PaletteFileListBox::onTick, this));
+}
+
+bool PaletteFileListBox::onProcessMessage(ui::Message* msg) {
+  switch (msg->type()) {
+    case kOpenMessage: {
+      m_resourcesTimer.start();
+      break;
+    }
+  }
+  return ListBox::onProcessMessage(msg);
+}
+
+void PaletteFileListBox::onTick() {
   if (m_resourcesLoader == NULL) {
     stop();
     return;
   }
-
-  if (!m_loadingItem) {
-    m_loadingItem = new LoadingItem;
-    addChild(m_loadingItem);
-  }
-  m_loadingItem->makeProgress();
-
-  base::UniquePtr<Resource> resource;
-  std::string name;
-
-  if (!m_resourcesLoader->next(resource)) {
-    if (m_resourcesLoader->isDone()) {
-      stop();
-
-      LOG("Done\n");
+  setLoading(true);
+  while (true) {
+    base::UniquePtr<Resource> resource;
+    if (!m_resourcesLoader->next(resource)) {
+        if (m_resourcesLoader->isDone()) {
+            stop();
+            LOG("Done\n");
+        }
+        return;
     }
-    return;
+    addPalette(static_cast<PaletteResource*>(resource.release()));
   }
-
-  PaletteResource* palResource = static_cast<PaletteResource*>(resource.get());
-  base::UniquePtr<PaletteListItem> listItem(new PaletteListItem(palResource));
-  insertChild(getItemsCount()-1, listItem);
-  layout();
-
-  View* view = View::getView(this);
-  if (view)
-    view->updateView();
-
-  resource.release();
-  listItem.release();
 }
 
-void PaletteListBox::stop()
-{
-  if (m_loadingItem) {
-    removeChild(m_loadingItem);
-    delete m_loadingItem;
-    m_loadingItem = NULL;
-
-    invalidate();
-  }
-
+void PaletteFileListBox::stop() {
+  setLoading(false);
   m_resourcesTimer.stop();
 }
 

--- a/src/app/ui/palette_listbox.h
+++ b/src/app/ui/palette_listbox.h
@@ -5,8 +5,6 @@
 // it under the terms of the GNU General Public License version 2 as
 // published by the Free Software Foundation.
 
-#ifndef APP_UI_PALETTE_LISTBOX_H_INCLUDED
-#define APP_UI_PALETTE_LISTBOX_H_INCLUDED
 #pragma once
 
 #include "app/res/resources_loader.h"
@@ -16,27 +14,37 @@
 #include "ui/timer.h"
 
 namespace app {
+  class PaletteResource;
 
   class PaletteListBox : public ui::ListBox {
   public:
-    PaletteListBox();
-
+    PaletteListBox() = default;
+    PaletteResource* selectedPaletteResource();
     doc::Palette* selectedPalette();
+    std::string selectedPaletteName();
     base::Signal1<void, doc::Palette*> PalChange;
+    void addPalette(PaletteResource* resource);
+    void addPalette(doc::Palette *palette, const std::string& name);
+
+  protected:
+    void setLoading(bool isLoading);
+    virtual void onChange();
+
+  private:
+    class LoadingItem;
+    LoadingItem* m_loadingItem = nullptr;
+  };
+
+  class PaletteFileListBox : public PaletteListBox {
+  public:
+    PaletteFileListBox();
 
   private:
     bool onProcessMessage(ui::Message* msg);
-    void onChange();
     void onTick();
     void stop();
-
-    ResourcesLoader* m_resourcesLoader;
+    base::UniquePtr<ResourcesLoader> m_resourcesLoader;
     ui::Timer m_resourcesTimer;
-
-    class LoadingItem;
-    LoadingItem* m_loadingItem;
   };
 
 } // namespace app
-
-#endif

--- a/src/app/ui/palette_listbox.h
+++ b/src/app/ui/palette_listbox.h
@@ -5,6 +5,16 @@
 // it under the terms of the GNU General Public License version 2 as
 // published by the Free Software Foundation.
 
+/*
+PaletteListBoxes are variants of ListBoxes that are only meant to show two kinds of ListItem:
+- its own PaletteListItem, which draws a name and a row of colors
+- a LoadingItem, an indicator that the list is still being loaded
+
+Since it is just a ui widget, it doesn't do much on its own and must be populated.
+PaletteFileListBox is a variation that populates itself by looking for palettes
+in the Filesystem.
+*/
+
 #pragma once
 
 #include "app/res/resources_loader.h"
@@ -44,6 +54,7 @@ namespace app {
     void onTick();
     void stop();
     std::unique_ptr<ResourcesLoader> m_resourcesLoader;
+    // To-do: Remove this
     ui::Timer m_resourcesTimer;
   };
 

--- a/src/app/ui/palette_listbox.h
+++ b/src/app/ui/palette_listbox.h
@@ -43,7 +43,7 @@ namespace app {
     bool onProcessMessage(ui::Message* msg);
     void onTick();
     void stop();
-    base::UniquePtr<ResourcesLoader> m_resourcesLoader;
+    std::unique_ptr<ResourcesLoader> m_resourcesLoader;
     ui::Timer m_resourcesTimer;
   };
 

--- a/src/app/ui/palette_popup.h
+++ b/src/app/ui/palette_popup.h
@@ -36,7 +36,7 @@ namespace app {
 
   private:
     gen::PalettePopup* m_popup;
-    PaletteListBox m_paletteListBox;
+    PaletteFileListBox m_paletteListBox;
   };
 
 } // namespace app


### PR DESCRIPTION
PaletteListBox is now purely a UI widget for drawing lists of palettes.
PaletteFileListBox has the functionality of loading palettes from disk.
Closes https://github.com/LibreSprite/LibreSprite-proposals/issues/6