### PR TITLE
Add code quality issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/code_quality.md
+++ b/.github/ISSUE_TEMPLATE/code_quality.md
@@ -1,0 +1,16 @@
+---
+name: Code quality
+about: Have you seen bad code? Click here
+title: ''
+labels: code quality
+assignees: ''
+
+---
+##### What's wrong with the code?
+<!-- A clear and concise description of the poor quality you've noticed -->
+
+##### How should it be improved?
+<!-- A clear and concise description of what you think is a better approach -->
+
+##### Additional context  
+<!-- Add any other context about the issue here -->


### PR DESCRIPTION
Right now we have bugs here, and features/discussions/meta in the other repo, but a template for code quality reports (like https://github.com/LibreSprite/LibreSprite/pull/208#pullrequestreview-753360921) is missing. This PR adds it. It makes more sense having it here as it's not really a proposal, but more like something to improve the actual code (same as bugs)