### PR TITLE
General scripting improvements

### DIFF
--- a/src/app/commands/cmd_run_script.cpp
+++ b/src/app/commands/cmd_run_script.cpp
@@ -5,7 +5,6 @@
 // it under the terms of the GNU General Public License version 2 as
 // published by the Free Software Foundation.
 
-#include "base/string.h"
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -47,21 +46,12 @@ RunScriptCommand::RunScriptCommand()
 void RunScriptCommand::onLoadParams(const Params& params)
 {
   m_filename = params.get("filename");
-  if (base::get_file_path(m_filename).empty()) {
-    ResourceFinder rf;
-    rf.includeDataDir(base::join_path("scripts", m_filename).c_str());
-    if (rf.findFirst())
-      m_filename = rf.filename();
-  }
 }
 
 void RunScriptCommand::onExecute(Context* context)
 {
   script::EngineDelegate::setDefault("gui");
-  script::Engine::setDefault(base::string_to_lower(base::get_file_extension(m_filename)), false);
-  AppScripting engine;
-  engine.evalFile(m_filename);
-
+  AppScripting::evalFile(m_filename);
   ui::Manager::getDefault()->invalidate();
 }
 

--- a/src/app/console.cpp
+++ b/src/app/console.cpp
@@ -98,8 +98,8 @@ Console::~Console()
       // Open in foreground
       wid_console->openWindowInForeground();
     }
-
-    delete wid_console;         // window
+    if (wid_console->manager())
+      delete wid_console;         // window
     wid_console = NULL;
     want_close_flag = false;
   }

--- a/src/app/script/api/console_script.cpp
+++ b/src/app/script/api/console_script.cpp
@@ -9,6 +9,7 @@
 #include "app/console.h"
 #include "script/engine.h"
 #include <iostream>
+#include <sstream>
 
 class ConsoleScriptObject : public script::ScriptObject {
 public:
@@ -20,10 +21,20 @@ public:
 
   void _assert(bool condition, const std::string& msg){
     if (!condition)
-      log(msg);
+      log();
   }
 
-  void log(const std::string& str) {
+  void log() {
+    std::stringstream stream;
+    bool first = true;
+    for (auto& arg : script::Function::varArgs()) {
+      if (!first) {
+        stream << " ";
+      }
+      first = false;
+      stream << arg.str();
+    }
+    auto str = stream.str();
     std::cout << str << std::endl;
     if (app::App::instance()->isGui()) {
       app::Console().printf("%s\n", str.c_str());

--- a/src/app/script/app_scripting.h
+++ b/src/app/script/app_scripting.h
@@ -17,13 +17,16 @@ namespace script {
 namespace app {
 
   class AppScripting {
-  public:
-    void eval(const std::string& code);
-    void evalFile(const std::string& fileName);
-    void printLastResult();
+    void initEngine();
+    static std::string m_fileName;
 
-  private:
-    inject<script::Engine> m_engine;
+  public:
+    static const std::string& getFileName() {return m_fileName;}
+    static bool evalFile(const std::string& fileName);
+    static void raiseEvent(const std::string& fileName, const std::string& event);
+
+    bool eval(const std::string& code);
+    void printLastResult();
   };
 
 } // namespace app

--- a/src/script/duktape/engine.cpp
+++ b/src/script/duktape/engine.cpp
@@ -140,7 +140,7 @@ public:
   }
 };
 
-static Engine::Regular<DukEngine> registration("js");
+static Engine::Regular<DukEngine> registration("duk", {"js"});
 
 class DukScriptObject : public InternalScriptObject {
 public:

--- a/src/script/engine.h
+++ b/src/script/engine.h
@@ -12,16 +12,32 @@
 
 namespace script {
   class Engine : public Injectable<Engine> {
+  protected:
+    void execAfterEval(bool success) {
+      for (auto& listener : m_afterEvalListeners) {
+        listener(success);
+      }
+      m_afterEvalListeners.clear();
+    }
+
   public:
+
     void initGlobals() {
-      m_scriptObjects = ScriptObject::getAllWithFlag("global");
+      if (m_scriptObjects.empty())
+        m_scriptObjects = ScriptObject::getAllWithFlag("global");
     }
 
     virtual void printLastResult() = 0;
     virtual bool eval(const std::string& code) = 0;
+    virtual bool raiseEvent(const std::string& event) = 0;
+
+    void afterEval(std::function<void(bool)>&& callback) {
+      m_afterEvalListeners.emplace_back(std::move(callback));
+    }
 
   private:
     Provides m_provides{this};
     std::vector<inject<ScriptObject>> m_scriptObjects;
+    std::vector<std::function<void(bool)>> m_afterEvalListeners;
   };
 }

--- a/src/script/function.h
+++ b/src/script/function.h
@@ -93,10 +93,19 @@ namespace script {
     std::function<void(Value&, std::vector<Value>&)> call;
     std::size_t argCount;
 
+    static inline std::vector<Value>** getVarArgsPtr() {
+      static std::vector<Value>* ptr = nullptr;
+      return &ptr;
+    }
+
   public:
     std::vector<Value> defaults;
     std::vector<Value> arguments;
     Value result;
+
+    static std::vector<Value>& varArgs() {
+      return **getVarArgsPtr();
+    }
 
     Function() : call([](Value& ret, std::vector<Value>&){}), argCount(0) {}
 
@@ -116,6 +125,7 @@ namespace script {
     template<typename NativeFunction>
     Function(NativeFunction&& func) : argCount(function_traits<NativeFunction>::arity) {
       call = [func](Value& result, std::vector<Value>& arguments) {
+        *getVarArgsPtr() = &arguments;
         result = function_traits<NativeFunction>::call(func, arguments.data());
       };
     }

--- a/src/script/value.h
+++ b/src/script/value.h
@@ -119,6 +119,7 @@ namespace script {
     }
 
 // STRING
+    Value(std::string&& i) { *this = std::move(i); }
     Value(const std::string& i) { *this = i; }
 
     Value& operator = (const std::string& i) {
@@ -127,15 +128,31 @@ namespace script {
       } else {
         makeUndefined();
         type = Type::STRING;
-        data.string_v = new std::string(i);;
+        data.string_v = new std::string(i);
       }
       return *this;
     }
 
-    operator std::string () const {
+
+    Value& operator = (std::string&& i) {
+      if (type == Type::STRING) {
+        *data.string_v = std::move(i);
+      } else {
+        makeUndefined();
+        type = Type::STRING;
+        data.string_v = new std::string(std::move(i));
+      }
+      return *this;
+    }
+
+    std::string str() const {
       if (type == Type::INT) return std::to_string(data.int_v);
       if (type == Type::DOUBLE) return std::to_string(data.double_v);
       return type == Type::STRING ? *data.string_v : std::string{};
+    }
+
+    operator std::string () const {
+      return str();
     }
 
     operator const char* () const {


### PR DESCRIPTION
This PR does a general clean-up of minor issues with the scripting system. In the process, I've made it possible to send events to scripts and to recycle scripting engine instances so that it doesn't have to setup and tear down the environment multiple times. If a script were to execute each time the mouse moved, for example, you'd need it to be as efficient as possible.

- Allow moving a string into a Value to prevent copying large strings
- Support for vararg API functions such as console.log
- Fix crash when closing app with console open
- Implement vararg support in console.log/assert
- Allow registering injectables with a set of flags
- Allow scripts to listen to events and recycle engine instances
