### PR TITLE
Warn about scripts being an experimental feature

### DIFF
--- a/data/gui.xml
+++ b/data/gui.xml
@@ -779,6 +779,8 @@
         <item command="Refresh" text="&amp;Refresh &amp;&amp; Reload Skin" />
       </menu>
       <menu id="script_list" text="S&amp;cripts">
+        <item text="BEWARE: experimental feature!" />
+        <separator />
         <item command="OpenScriptsFolder" text="Open &amp;Folder" />
         <item command="RescanScripts" text="Rescan scripts"/>
         <separator />

--- a/data/gui.xml
+++ b/data/gui.xml
@@ -779,7 +779,7 @@
         <item command="Refresh" text="&amp;Refresh &amp;&amp; Reload Skin" />
       </menu>
       <menu id="script_list" text="S&amp;cripts">
-        <item text="BEWARE: experimental feature!" />
+        <item text="Note: experimental feature!" />
         <separator />
         <item command="OpenScriptsFolder" text="Open &amp;Folder" />
         <item command="RescanScripts" text="Rescan scripts"/>


### PR DESCRIPTION
As 1.0 is not gonna roll out a stable scripting system, a warn has been added (clicking it doesn't do anything but closing the dropdown menu)

![imagen](https://user-images.githubusercontent.com/63455151/134390822-71a8bed1-e50e-4c4a-b3a4-7a8ce40e98dc.png)

