### PR TITLE
Further improvements to the devconsole

### DIFF
--- a/src/app/script/api/console_script.cpp
+++ b/src/app/script/api/console_script.cpp
@@ -8,11 +8,14 @@
 #include "app/app.h"
 #include "app/console.h"
 #include "script/engine.h"
+#include "script/engine_delegate.h"
 #include <iostream>
 #include <sstream>
 
 class ConsoleScriptObject : public script::ScriptObject {
 public:
+  inject<script::EngineDelegate> delegate;
+
   ConsoleScriptObject() {
     addMethod("log", this, &ConsoleScriptObject::log);
     addMethod("assert", this, &ConsoleScriptObject::_assert);
@@ -35,10 +38,7 @@ public:
       stream << arg.str();
     }
     auto str = stream.str();
-    std::cout << str << std::endl;
-    if (app::App::instance()->isGui()) {
-      app::Console().printf("%s\n", str.c_str());
-    }
+    delegate->onConsolePrint(str.c_str());
   }
 };
 

--- a/src/app/ui/devconsole_view.h
+++ b/src/app/ui/devconsole_view.h
@@ -13,6 +13,7 @@
 #include "app/ui/workspace_view.h"
 #include "script/engine_delegate.h"
 #include "ui/box.h"
+#include "ui/combobox.h"
 #include "ui/label.h"
 #include "ui/textbox.h"
 #include "ui/view.h"
@@ -52,7 +53,7 @@ namespace app {
     ui::View m_view;
     ui::TextBox m_textBox;
     ui::HBox m_bottomBox;
-    app::DropDownButton m_language;
+    ui::ComboBox m_language;
     ui::Label m_label;
     CommmandEntry* m_entry;
     Provides m_dev{this};


### PR DESCRIPTION
Language dropdown is no longer a button.
Console.log(...) now shows up in the console instead of a separate pop-up.