### PR TITLE
Allow scripts to alter a sprite's palette

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -338,6 +338,7 @@ add_library(app-lib
   script/api/image_script.cpp
   script/api/layer_script.cpp
   script/api/pixelcolor_script.cpp
+  script/api/palette_script.cpp
   script/api/sprite_script.cpp
   script/api/selection_script.cpp
 

--- a/src/app/script/api/palette_script.cpp
+++ b/src/app/script/api/palette_script.cpp
@@ -1,0 +1,65 @@
+// LibreSprite
+// Copyright (C) 2021  LibreSprite contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 2 as
+// published by the Free Software Foundation.
+
+#include "app/modules/palettes.h"
+#include "doc/palette.h"
+#include "doc/image.h"
+#include "doc/sprite.h"
+#include "ui/manager.h"
+#include "script/script_object.h"
+#include "script/engine.h"
+
+class PaletteScriptObject : public script::ScriptObject {
+public:
+  PaletteScriptObject() {
+    addProperty("length",
+                [this]{return m_pal->size();},
+                [this](int s){m_pal->resize(s); modify(); return s;});
+
+    addFunction("get", [this](int i){return m_pal->getEntry(i);});
+
+    addMethod("set", &PaletteScriptObject::set);
+  }
+
+  void modify() {
+      if (needIncrement)
+          return;
+      needIncrement = true;
+      m_engine->afterEval([=](bool success){
+          m_pal->incrementVersion();
+          app::set_current_palette(m_pal, true);
+          ui::Manager::getDefault()->invalidate();
+          needIncrement = false;
+      });
+  }
+
+  void set(int i){
+      if (i >= m_pal->size())
+          return;
+      auto& args = script::Function::varArgs();
+      int c;
+      if (args.size() == 2) {
+          c = args[1];
+      } else if(args.size() == 4) {
+          c = doc::rgba(args[1], args[2], args[3], 0xFF);
+      } else if(args.size() == 5) {
+          c = doc::rgba(args[1], args[2], args[3], args[4]);
+      } else
+          return;
+      m_pal->setEntry(i, c);
+      modify();
+  }
+
+  void* getWrapped() override {return m_pal;}
+  void setWrapped(void* pal) override {m_pal = static_cast<doc::Palette*>(pal);}
+
+  bool needIncrement = false;
+  doc::Palette* m_pal = nullptr;
+  inject<script::Engine> m_engine;
+};
+
+static script::ScriptObject::Regular<PaletteScriptObject> celSO("PaletteScriptObject");

--- a/src/app/script/api/sprite_script.cpp
+++ b/src/app/script/api/sprite_script.cpp
@@ -20,12 +20,19 @@
 class SpriteScriptObject : public script::ScriptObject {
   Provides provides{this, "activeSprite"};
   inject<ScriptObject> m_document{"activeDocument"};
+  inject<ScriptObject> m_pal{"PaletteScriptObject"};
   doc::Sprite* m_sprite;
   std::unordered_map<doc::Layer*, inject<ScriptObject>> m_layers;
   std::unique_ptr<app::Transaction> m_transaction;
 
 public:
-  SpriteScriptObject() : m_sprite{doc()->sprite()} {
+  SpriteScriptObject() {
+    if (m_document) {
+      m_sprite = doc()->sprite();
+      if (m_pal)
+        m_pal->setWrapped(m_sprite->palette(app::frame_t(0)));
+    }
+
     addProperty("layerCount", [this]{return (int) m_sprite->countLayers();})
       .doc("read-only. Returns the amount of layers in the sprite.");
 
@@ -53,6 +60,8 @@ public:
 
     addProperty("selection", [this]{ return this; })
       .doc("placeholder. Do not use.");
+
+    addProperty("palette", [this]{ return m_pal.get(); });
 
     addMethod("layer", &SpriteScriptObject::layer)
       .doc("allows you to access a given layer.")


### PR DESCRIPTION
Example script:
```js
const pal = app.activeSprite.palette;
for (var i = 0; i < pal.length; ++i)
  pal.set(i, Math.random() * 255, Math.random() * 255, Math.random() * 255);
```