### PR TITLE
Remove V8 pointers compression on 32-bit architectures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,7 +190,13 @@ endif()
 find_package(V8)
 if(V8_FOUND)
   include_directories(${V8_INCLUDE_DIR})
-  add_definitions(-DSCRIPT_ENGINE_V8=1 -DV8_COMPRESS_POINTERS)
+  add_definitions(-DSCRIPT_ENGINE_V8=1)
+
+  # pointers compression doesn't work on 32bit machines
+  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    add_definitions(-DV8_COMPRESS_POINTERS)
+  endif()
+
   message(STATUS "Optional V8 library found. Enabling V8 scripting engine.")
 else()
   message(STATUS "Optional V8 library NOT found. Disabling V8 scripting engine.")


### PR DESCRIPTION
It wasn't possible to compile on 32-bit architectures due to V8 pointers compression, a feature that only works on 64-bit architectures
