### PR TITLE
Fixes bug that prevents compiling on mac.

### DIFF
--- a/src/ui/manager.cpp
+++ b/src/ui/manager.cpp
@@ -33,11 +33,11 @@
 #include <iostream>
 #endif
 
+#include <array>
 #include <deque>
 #include <limits>
 #include <list>
 #include <vector>
-#include <array>
 
 namespace ui {
 

--- a/src/ui/manager.cpp
+++ b/src/ui/manager.cpp
@@ -37,6 +37,7 @@
 #include <limits>
 #include <list>
 #include <vector>
+#include <array>
 
 namespace ui {
 


### PR DESCRIPTION
The bug when compiling:
```
/Users/user1/LibreSprite/src/ui/manager.cpp:66:38: error: implicit instantiation of undefined template 'std::array<std::list<ui::Filter>, 22>'
static std::array<Filters, NFILTERS> msg_filters; // Filters for every enqueued message
                                     ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__tuple:219:64: note: template is declared here
template <class _Tp, size_t _Size> struct _LIBCPP_TEMPLATE_VIS array;
                                                               ^
```

<br>

Line 66 of `manager.cpp` can't run because it can't find the `array` data-type.
```c
static std::array<Filters, NFILTERS> msg_filters; // Filters for every enqueued message
```

Adding `#include <array>` to the file fixes the bug and allows libresprite to build and run on mac (M1).