### PR TITLE
Fix transparent color rendering in palette: fixes #315

### DIFF
--- a/src/gfx/color.h
+++ b/src/gfx/color.h
@@ -33,5 +33,6 @@ namespace gfx {
   inline ColorComponent geta(Color c) { return (c >> ColorAShift) & 0xff; }
 
   inline bool is_transparent(Color c) { return geta(c) == 0; }
+  inline bool is_solid(Color c) { return geta(c) == 255; }
 
 } // namespace gfx

--- a/src/she/sdl2/sdl2_surface.cpp
+++ b/src/she/sdl2/sdl2_surface.cpp
@@ -53,7 +53,7 @@ namespace she {
 
   SDL2Surface::SDL2Surface(SDL_Surface* bmp, DestroyFlag destroy)
     : m_bmp(bmp)
-    , m_tmp(SDL_CreateRGBSurface(0, bmp->w/3, bmp->h/3, bmp->format->BitsPerPixel, 0xFF, 0xFF00, 0xFF0000, bmp->format->BitsPerPixel == 32 ? 0xFF000000 : 0))
+    , m_tmp(SDL_CreateRGBSurface(0, 1, 1, bmp->format->BitsPerPixel, 0xFF, 0xFF00, 0xFF0000, bmp->format->BitsPerPixel == 32 ? 0xFF000000 : 0))
     , m_destroy(destroy)
     , m_lock(0)
   {
@@ -61,7 +61,7 @@ namespace she {
 
   SDL2Surface::SDL2Surface(int width, int height, DestroyFlag destroy)
     : m_bmp(SDL_CreateRGBSurface(0, width, height, 32, 0xFF, 0xFF00, 0xFF0000, 0xFF000000))
-    , m_tmp(SDL_CreateRGBSurface(0, width/3, height/3, 32, 0xFF, 0xFF00, 0xFF0000, 0xFF000000))
+    , m_tmp(SDL_CreateRGBSurface(0, 1, 1, 32, 0xFF, 0xFF00, 0xFF0000, 0xFF000000))
     , m_destroy(destroy)
     , m_lock(0)
   {
@@ -72,7 +72,7 @@ namespace she {
 
   SDL2Surface::SDL2Surface(int width, int height, int bpp, DestroyFlag destroy)
     : m_bmp(SDL_CreateRGBSurface(0, width, height, bpp, 0xFF, 0xFF00, 0xFF0000, bpp == 32 ? 0xFF000000 : 0))
-    , m_tmp(SDL_CreateRGBSurface(0, width/3, height/3, bpp, 0xFF, 0xFF00, 0xFF0000, bpp == 32 ? 0xFF000000 : 0))
+    , m_tmp(SDL_CreateRGBSurface(0, 1, 1, bpp, 0xFF, 0xFF00, 0xFF0000, bpp == 32 ? 0xFF000000 : 0))
     , m_destroy(destroy)
     , m_lock(0)
   {
@@ -432,17 +432,10 @@ namespace she {
       SDL_FillRect(m_bmp, &rect, to_sdl(m_bmp->format, color));
     } else {
       // Color has transparency: paint the temporary surface with the color and blit it with alpha-blend
-      if (!m_tmp || m_tmp->h < rc.h || m_tmp->w < rc.w){
-        // Not enough space on the temporary surface
-        if (m_tmp){
-          SDL_FreeSurface(m_tmp);
-        }
-        m_tmp = SDL_CreateRGBSurface(0, rc.w, rc.h, m_bmp->format->BitsPerPixel, 0xFF, 0xFF00, 0xFF0000, m_bmp->format->BitsPerPixel == 32 ? 0xFF000000 : 0);
-      }
       SDL_SetSurfaceBlendMode(m_tmp, SDL_BLENDMODE_BLEND);
-      SDL_Rect rect_tmp{0, 0, rc.w, rc.h};
+      SDL_Rect rect_tmp{0, 0, 1, 1};
       SDL_FillRect(m_tmp, &rect_tmp, to_sdl(m_bmp->format, color));
-      SDL_BlitSurface(m_tmp, &rect_tmp, m_bmp, &rect);
+      SDL_BlitScaled(m_tmp, &rect_tmp, m_bmp, &rect);
     }
   }
 

--- a/src/she/sdl2/sdl2_surface.cpp
+++ b/src/she/sdl2/sdl2_surface.cpp
@@ -19,6 +19,7 @@
 #include "base/string.h"
 #include "gfx/point.h"
 #include "gfx/rect.h"
+#include "gfx/color.h"
 
 #include <iostream>
 
@@ -422,7 +423,17 @@ namespace she {
   void SDL2Surface::fillRect(gfx::Color color, const gfx::Rect& rc)
   {
     SDL_Rect rect{rc.x, rc.y, rc.w, rc.h};
-    SDL_FillRect(m_bmp, &rect, to_sdl(m_bmp->format, color));
+    if (gfx::is_solid(color)){
+        SDL_FillRect(m_bmp, &rect, to_sdl(m_bmp->format, color));
+    } else {
+        // Make temporary surface with the color and blit it with alpha-blend
+        SDL_Surface *surface_tmp = SDL_CreateRGBSurface(0, rc.w, rc.h, 32, 0xFF, 0xFF00, 0xFF0000, 0xFF000000);
+        SDL_SetSurfaceBlendMode(surface_tmp, SDL_BLENDMODE_BLEND);
+        SDL_Rect rect_tmp{0, 0, rc.w, rc.h};
+        SDL_FillRect(surface_tmp, &rect_tmp, to_sdl(m_bmp->format, color));
+        SDL_BlitSurface(surface_tmp, NULL, m_bmp, &rect);
+        SDL_FreeSurface(surface_tmp);
+    }
   }
 
   void SDL2Surface::blitTo(Surface* dest, int srcx, int srcy, int dstx, int dsty, int width, int height) const

--- a/src/she/sdl2/sdl2_surface.h
+++ b/src/she/sdl2/sdl2_surface.h
@@ -59,7 +59,6 @@ namespace she {
 
   private:
     SDL_Surface* m_bmp = nullptr;
-    SDL_Surface* m_tmp = nullptr;
     DestroyFlag m_destroy;
     int m_lock;
   };

--- a/src/she/sdl2/sdl2_surface.h
+++ b/src/she/sdl2/sdl2_surface.h
@@ -59,6 +59,7 @@ namespace she {
 
   private:
     SDL_Surface* m_bmp = nullptr;
+    SDL_Surface* m_tmp = nullptr;
     DestroyFlag m_destroy;
     int m_lock;
   };


### PR DESCRIPTION
<!-- be sure to check the copyright year of every file you've modified, and
in case, update it -->

Possible fix for #315 
Fixes the rendering issues on transparent colors

The PR works by generating a temporary surface with the color and blit it on top of the surface. 

## How to test
<!-- Example code or instructions -->
Run the program and chose a color in the palette. With the RGB mode, move the Alpha slider from 0 to 255.
It should show a grid and the chosen color on top, with the transparency level you set. Without the proposed changes it renders a weird background that is affected by user interaction like moving the mouse on top of it.