### PR TITLE
data search path for Apple Hardware

### DIFF
--- a/src/app/resource_finder.cpp
+++ b/src/app/resource_finder.cpp
@@ -102,6 +102,10 @@ void ResourceFinder::includeDataDir(const char* filename)
   sprintf(buf, "../Resources/data/%s", filename);
   includeBinDir(buf);  // $BINDIR/../Resources/data/filename (inside a bundle)
 
+  // $BINDIR/../share/libresprite/data/filename (installed in /usr/ or /usr/local/)
+  sprintf(buf, "../share/libresprite/data/%s", filename);
+  includeBinDir(buf);
+  
 #else
 
 

--- a/src/app/resource_finder.cpp
+++ b/src/app/resource_finder.cpp
@@ -1,5 +1,5 @@
 // Aseprite    | Copyright (C) 2001-2016  David Capello
-// LibreSprite | Copyright (C) 2018-2020  LibreSprite contributors
+// LibreSprite | Copyright (C) 2018-2022  LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as


### PR DESCRIPTION
Address https://github.com/LibreSprite/LibreSprite/issues/350

This just allows the app to search for the data folder in /usr/ or /usr/local/ like it would on most *nix systems.
