### PR TITLE
Correct license headers

### DIFF
--- a/src/base/dll_win32.h
+++ b/src/base/dll_win32.h
@@ -1,9 +1,8 @@
 // Aseprite    | Copyright (C) 2001-2016  David Capello
 // LibreSprite | Copyright (C) 2018-2022  LibreSprite contributors
 //
-// This program is free software; you can redistribute it and/or modify
-// it under the terms of the GNU General Public License version 2 as
-// published by the Free Software Foundation.
+// This file is released under the terms of the MIT license.
+// Read LICENSE.txt for more information.
 
 #include "base/string.h"
 #include <windows.h>

--- a/src/base/fs_win32.h
+++ b/src/base/fs_win32.h
@@ -1,9 +1,8 @@
 // Aseprite    | Copyright (C) 2001-2016  David Capello
 // LibreSprite | Copyright (C) 2018-2022  LibreSprite contributors
 //
-// This program is free software; you can redistribute it and/or modify
-// it under the terms of the GNU General Public License version 2 as
-// published by the Free Software Foundation.
+// This file is released under the terms of the MIT license.
+// Read LICENSE.txt for more information.
 
 #include <stdexcept>
 #include <windows.h>

--- a/src/base/launcher.cpp
+++ b/src/base/launcher.cpp
@@ -1,9 +1,8 @@
 // Aseprite    | Copyright (C) 2001-2016  David Capello
 // LibreSprite | Copyright (C) 2018-2022  LibreSprite contributors
 //
-// This program is free software; you can redistribute it and/or modify
-// it under the terms of the GNU General Public License version 2 as
-// published by the Free Software Foundation.
+// This file is released under the terms of the MIT license.
+// Read LICENSE.txt for more information.
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"

--- a/src/base/memory_dump_win32.h
+++ b/src/base/memory_dump_win32.h
@@ -1,9 +1,8 @@
 // Aseprite    | Copyright (C) 2001-2016  David Capello
 // LibreSprite | Copyright (C) 2018-2022  LibreSprite contributors
 //
-// This program is free software; you can redistribute it and/or modify
-// it under the terms of the GNU General Public License version 2 as
-// published by the Free Software Foundation.
+// This file is released under the terms of the MIT license.
+// Read LICENSE.txt for more information.
 
 #pragma once
 


### PR DESCRIPTION
<!-- be sure to check the copyright year of every file you've modified, and
in case, update it -->

Add compact, short information about your PR for easier understanding:

- Goal of the PR
A few days ago I submitted PR #371, which also updated the license & copyright info on each file.  In doing so I (wrongfully) changed the license from MIT to GPL.  This PR will restore the MIT text at the top of those 4 files.
- How does the PR work?
1. This PR Replaces...
```
// This program is free software; you can redistribute it and/or modify
// it under the terms of the GNU General Public License version 2 as
// published by the Free Software Foundation.
```
2. With...
```
// This file is released under the terms of the MIT license.
// Read LICENSE.txt for more information.
```
- Does it resolve any reported issue?
No.

## How to test
<!-- Example code or instructions -->
1. Ensure license header in `fs_win32.h`, `launcher.cpp`, `memory_dump_win32.h`, and `dll_win32.h` match that of the other files in `src/base/`.
2.  The copyright headers should still contain:
```
// Aseprite    | Copyright (C) 2001-2016  David Capello
// LibreSprite | Copyright (C) 2018-2022  LibreSprite contributors
```
3. The wide character calls should remain untouched.

_Sorry about the mistake!_
