### PR TITLE
Detect system v8 library pointer compression.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Aseprite     | Copyright (C) 2001-2016  David Capello
-# LibreSprite  | Copyright (C)      2021  LibreSprite contributors
+# LibreSprite  | Copyright (C)      2022  LibreSprite contributors
 
 cmake_minimum_required(VERSION 3.4)
 
@@ -192,9 +192,33 @@ if(V8_FOUND)
   include_directories(${V8_INCLUDE_DIR})
   add_definitions(-DSCRIPT_ENGINE_V8=1)
 
+  include(CheckCXXSourceRuns)
+  set(CMAKE_REQUIRED_LIBRARIES ${V8_LIBRARY} ${V8_LIBBASE_LIBRARY} ${V8_LIBPLATFORM_LIBRARY})
+  set(CMAKE_REQUIRED_INCLUDES ${V8_INCLUDE_DIR})
+  message(STATUS ${V8_POINTER_COMPRESSION_OUTPUT})
+  # Since V8_COMPRESS_POINTERS is not defined here, the resulting program would
+  # die if the system v8 library had enabled pointer compression.
+  check_cxx_source_runs("
+    #include <v8.h>
+    #include <libplatform/libplatform.h>
+    int main(void) {
+      v8::V8::InitializeICU();
+      static std::unique_ptr<v8::Platform> m_platform;
+      m_platform = v8::platform::NewDefaultPlatform();
+      v8::V8::InitializePlatform(m_platform.get());
+      v8::V8::Initialize();
+      return 0;
+    }
+	" DISABLE_POINTER_COMPRESSION)
+
   # pointers compression doesn't work on 32bit machines
   if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-    add_definitions(-DV8_COMPRESS_POINTERS)
+    if(DISABLE_POINTER_COMPRESSION EQUAL 1)
+      message(STATUS "Disabling V8 pointer compression")
+    else()
+      message(STATUS "Enabling V8 pointer compression")
+      add_definitions(-DV8_COMPRESS_POINTERS)
+    endif()
   endif()
 
   message(STATUS "Optional V8 library found. Enabling V8 scripting engine.")


### PR DESCRIPTION
<!-- be sure to check the copyright year of every file you've modified, and
in case, update it -->

- Disables V8 pointer compression when the system v8 library has disabled pointer compression (fixes #383).

## How to test

- [x] Build on Debian and verify running a JS script does not crash (works on Debian/bookworm).
- [x] Build on Fedora and verify running a JS script does not crash (works on Fedora 37). Using this `Dockerfile`:

```
FROM fedora:37

RUN echo "assumeyes=True" >> /etc/dnf/dnf.conf 
RUN dnf install g++ cmake libcurl-devel freetype-devel giflib-devel gtest-devel libjpeg-devel lua-devel pixman-devel libpng-devel SDL2-devel SDL2_image-devel tinyxml-devel zlib-devel ninja-build nodejs-devel
RUN dnf install git

RUN mkdir /app
RUN mkdir /src
WORKDIR /src
RUN git clone --recursive --branch detect-pointer-compression https://github.com/dvogel/LibreSprite.git
RUN mkdir /src/LibreSprite/build
WORKDIR /src/LibreSprite/build
RUN cmake -DCMAKE_INSTALL_PREFIX=/app -DV8_INCLUDE_DIR=/usr/include/node -DV8_LIBRARY=/usr/lib64/libv8.so.10 -DV8_LIBBASE_LIBRARY=/usr/lib64/libv8_libbase.so.10 -DV8_LIBPLATFORM_LIBRARY=/usr/lib64/libv8_libplatform.so.10 -G Ninja ..
RUN ninja libresprite
RUN ninja install

ENV USER libresprite-runner
ENV HOME /home
RUN mkdir -p /home/.config/libresprite/scripts/
RUN touch /home/.config/libresprite/scripts/DoNothing.js
WORKDIR /home

ENTRYPOINT ["/bin/bash"]
```

This command works with this branch but crashes (as in #383) when built with the `master` branch:
```
docker run --rm -it -e uid="$(id -u)" -e gid="$(id -g)" libresprite-test -c '/app/bin/libresprite --batch --script /home/.config/libresprite/scripts/DoNothing.js'
```

- [ ] Regression testing on other platforms to ensure pointer compression is still enabled there. @felipemanga it sounded on #383 like you knew of some linux distros that enabled pointer compression on 64-bit platforms. Mind pointing me toward one for testing? I found [an issue for nodejs](https://github.com/nodejs/TSC/issues/790) where the TSC decided against making pointer compression the default for the v8 library they ship.
