### PR TITLE
Fix repo URL in MacOS workflow

### DIFF
--- a/.github/workflows/cmakeMacOs.yml
+++ b/.github/workflows/cmakeMacOs.yml
@@ -46,7 +46,7 @@ jobs:
 
     - name: Download & Lint Info.plist
       run: |
-        curl -L https://raw.githubusercontent.com/pegvin/LibreSprite/master/desktop/Info.plist --output desktop/Info.plist
+        curl -L https://raw.githubusercontent.com/LibreSprite/LibreSprite/master/desktop/Info.plist --output desktop/Info.plist
         plutil desktop/Info.plist
 
     - name: Generate Makefiles


### PR DESCRIPTION
This aims to address the issue causing the latest MacOS build to fail. See <https://github.com/LibreSprite/LibreSprite/actions/runs/5983905854/job/16234566625>. The URL is incorrect (not pulling the plist from LibreSprite/LibreSprite) so I have pointed it to the right place.

## How to test

it's github, no idea lol