### PR TITLE
ci: bump checkout & upload-artifacts to v3

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     # install dependencies
     - name: update
       run: sudo apt-get update

--- a/.github/workflows/cmakeAndroid.yml
+++ b/.github/workflows/cmakeAndroid.yml
@@ -39,7 +39,7 @@ jobs:
         cd ..
 #        ls -R android/app/build
     - name: Archive production artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: libresprite-development-android
         path: |

--- a/.github/workflows/cmakeMacOs.yml
+++ b/.github/workflows/cmakeMacOs.yml
@@ -14,7 +14,7 @@ jobs:
   build-x86_64:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: 'stable-1.x'
 
@@ -94,14 +94,14 @@ jobs:
         dylibbundler -od -b -ns -x ./bundle/libresprite.app/Contents/MacOS/libresprite -d ./bundle/libresprite.app/Contents/libs/
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: macos-x86_64
         path: ./build/bin/
         if-no-files-found: error
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: macos-x86_64-bundle
         path: ./bundle/

--- a/.github/workflows/cmakeWin32.yml
+++ b/.github/workflows/cmakeWin32.yml
@@ -38,7 +38,7 @@ jobs:
           mingw-w64-i686-zlib
           mingw-w64-i686-libarchive
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: 'true'
     - shell: msys2 {0}
@@ -51,7 +51,7 @@ jobs:
         node package_win.js build/bin/libresprite.exe
         cp /mingw32/bin/snapshot_blob.bin ./build/bin
     - name: Archive production artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: libresprite-development-windows-i686
         path: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -47,7 +47,7 @@ jobs:
       with:
         languages: ${{ matrix.language }}
     
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     # install dependencies
     - name: update
       run: sudo apt-get update

--- a/.github/workflows/submodules-CD.yml
+++ b/.github/workflows/submodules-CD.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: checkout modules
         run: git submodule update --init --recursive


### PR DESCRIPTION
the github ci trows a warning cause these two actions run on a deprecated version on node; fix it, at least for now

finding all the warning is hard

check the annotations section for the warnings https://github.com/LibreSprite/LibreSprite/actions/runs/7314194370
<!-- be sure to check the copyright year of every file you've modified, and
in case, update it -->

## How to test
<!-- Example code or instructions -->
