### PR TITLE
fix out of bounds array access

### DIFF
--- a/src/she/sdl2/sdl2_display.cpp
+++ b/src/she/sdl2/sdl2_display.cpp
@@ -273,7 +273,7 @@ namespace she {
 
   void applyCursor(SDL_SystemCursor id)
   {
-    if (id <= m_cursors.size()) {
+    if (id >= m_cursors.size()) {
       m_cursors.resize(id + 1);
     }
     if (!m_cursors[id]) {


### PR DESCRIPTION
Without this LibreSprite aborts when compiled with glibcxx asserts.