### PR TITLE
Remove anti alias from font popup

### DIFF
--- a/src/app/ui/editor/standby_state.cpp
+++ b/src/app/ui/editor/standby_state.cpp
@@ -286,6 +286,12 @@ bool StandbyState::onMouseDown(Editor* editor, MouseMessage* msg)
       if (handle.rect().contains(msg->position())) {
         auto& symmetry = Preferences::instance().document(editor->document()).symmetry;
         const auto& axis = handle.axis();
+        switch (Axis::HORIZONTAL) {
+          case true:
+            symmetry.yAxis.setDefaultValue(editor->getVisibleSpriteBounds().w / 2);
+          case false:
+            symmetry.xAxis.setDefaultValue(editor->getVisibleSpriteBounds().h / 2);
+        }
         auto& axisPos = axis == Axis::HORIZONTAL ? symmetry.xAxis : symmetry.yAxis;
 
         editor->setState(

--- a/src/app/ui/font_popup.cpp
+++ b/src/app/ui/font_popup.cpp
@@ -108,7 +108,7 @@ private:
                     gfx::getg(color),
                     gfx::getb(color),
                     gfx::geta(color)),
-          true));                   // antialias
+          false));                   // antialias
 
       View* view = View::getView(listbox);
       view->updateView();

--- a/src/app/ui/font_popup.cpp
+++ b/src/app/ui/font_popup.cpp
@@ -1,5 +1,5 @@
 // Aseprite    | Copyright (C) 2001-2016  David Capello
-// LibreSprite | Copyright (C)      2021  LibreSprite contributors
+// LibreSprite | Copyright (C)      2024  LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as


### PR DESCRIPTION
<!-- be sure to check the copyright year of every file you've modified, and
in case, update it -->

Remove anti alias in font previews to accurately reflect how the text will look when added to the sprite.

## How to test
<!-- Example code or instructions -->