### PR TITLE
Fix symmetry bug when sprite sheet is imported

### DIFF
--- a/src/app/commands/cmd_import_sprite_sheet.cpp
+++ b/src/app/commands/cmd_import_sprite_sheet.cpp
@@ -313,6 +313,11 @@ void ImportSpriteSheetCommand::onExecute(Context* context)
 
   Document* document = window.document();
   DocumentPreferences* docPref = window.docPref();
+
+  // Set symmetry preference values because they are initially loaded when the window is
+  docPref->symmetry.xAxis.setValueAndDefault(window.frameBounds().h/2);
+  docPref->symmetry.yAxis.setValueAndDefault(window.frameBounds().w/2);
+
   gfx::Rect frameBounds = window.frameBounds();
   bool partialTiles = window.partialTilesValue();
   auto sheetType = window.sheetTypeValue();

--- a/src/app/commands/cmd_import_sprite_sheet.cpp
+++ b/src/app/commands/cmd_import_sprite_sheet.cpp
@@ -315,8 +315,8 @@ void ImportSpriteSheetCommand::onExecute(Context* context)
   DocumentPreferences* docPref = window.docPref();
 
   // Set symmetry preference values because they are initially loaded when the window is
-  docPref->symmetry.xAxis.setValueAndDefault(window.frameBounds().h/2);
-  docPref->symmetry.yAxis.setValueAndDefault(window.frameBounds().w/2);
+  docPref->symmetry.xAxis.setValueAndDefault(window.frameBounds().w/2);
+  docPref->symmetry.yAxis.setValueAndDefault(window.frameBounds().h/2);
 
   gfx::Rect frameBounds = window.frameBounds();
   bool partialTiles = window.partialTilesValue();


### PR DESCRIPTION
<!-- be sure to check the copyright year of every file you've modified, and
in case, update it -->

Solves bug #449 

## How to test
- Compile and run
- Import an image of a sprite sheet that has not been imported before
- If it is working, the lines should default to the center of the sprite
- Previous behavior was that the lines appear off the sprite
