### PR TITLE
fix compilation error on FreeBSD

### DIFF
--- a/src/app/script/api/console_script.cpp
+++ b/src/app/script/api/console_script.cpp
@@ -1,5 +1,5 @@
 // LibreSprite
-// Copyright (C) 2021  LibreSprite contributors
+// Copyright (C) 2024  LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as
@@ -11,6 +11,10 @@
 #include "script/engine_delegate.h"
 #include <iostream>
 #include <sstream>
+
+#if defined(__FreeBSD__)
+#undef _assert
+#endif
 
 class ConsoleScriptObject : public script::ScriptObject {
 public:


### PR DESCRIPTION
There was a conflict with FreeBSD's assert header, so undef the macro.

- Goal of the PR
Build on FreeBSD
- How does the PR work?
Resolve namespace conflict
- Does it resolve any reported issue?
~~I dunno~~
https://github.com/LibreSprite/LibreSprite/issues/479

## How to test
build on FreeBSD before and after commit.
