### PR TITLE
Use return value of getcwd

### DIFF
--- a/src/base/fs_unix.h
+++ b/src/base/fs_unix.h
@@ -120,7 +120,8 @@ void remove_directory(const std::string& path)
 std::string get_current_path()
 {
   std::vector<char> path(MAXPATHLEN);
-  getcwd(&path[0], path.size());
+  if (getcwd(&path[0], path.size()) == NULL)
+    return "";
   return std::string(&path[0]);
 }
 


### PR DESCRIPTION
Removes compiler warning and avoids call to std::string constructor with NULL as arg.

Goal of the PR : check return value of `getcwd` to avoid calling `std::string` constructor call when path not found or too long.
Resolves: https://github.com/LibreSprite/LibreSprite/issues/516

## How to test
Do normal build. `ninja libresprite` step should have 1 less compiler warning when built on *nix systems.
