### PR TITLE
Build Tooling: Use sharun and AppImageTool to package AppImages

### DIFF
--- a/.github/workflows/cmakeLinux.yml
+++ b/.github/workflows/cmakeLinux.yml
@@ -35,11 +35,13 @@ jobs:
     - name: appimage
       run: |
         cd build/bin
+        export ARCH="$(uname -m)"
         sh ../../package_linux.sh
-        mv ./LibreSprite-x86_64.AppImage ../../
+        mv ./LibreSprite-anylinux-$ARCH.AppImage ../../
     - name: Archive production artifacts
+      if: runner.arch == 'X64'
       uses: actions/upload-artifact@v4
       with:
         name: libresprite-development-linux-x86_64
-        path: LibreSprite-x86_64.AppImage
+        path: LibreSprite-anylinux-x86_64.AppImage
         if-no-files-found: error

--- a/package_linux.sh
+++ b/package_linux.sh
@@ -3,13 +3,17 @@
 
 out=$(pwd)
 src=$(pwd)
+APP="LibreSprite"
+ARCH="$(uname -m)"
 
 chmod +x libresprite
 
-mkdir -p LibreSprite
+mkdir -p LibreSprite/usr/bin
 
 mv ../../desktop/libresprite.desktop LibreSprite/
 cp ../../desktop/icons/hicolor/256x256/apps/libresprite.png LibreSprite/libresprite.png
+
+mv *.so* LibreSprite/usr/lib
 
 # Create AppImage with lib4bin and Sharun
 (
@@ -18,11 +22,21 @@ cd LibreSprite
 wget "https://raw.githubusercontent.com/VHSgunzo/sharun/refs/heads/main/lib4bin" -O ./lib4bin
 chmod +x ./lib4bin
 xvfb-run -a -- ./lib4bin -p -v -e -r -k -w \
-  /usr/bin/libresprite \
-  /usr/bin/data \
+  ../libresprite \
   /usr/lib/libpthread.so* \
   /usr/lib/librt.so* \
   /usr/lib/libstdc++.so* 
 ln ./sharun ./AppRun 
 ./sharun -g
 )
+
+# Maybe the data folder is being read during initial run
+# This lets the run complete with expected original locations and then
+# copies it over afterwards using the below command
+mv "$out"/data "$out"/LibreSprite/bin
+
+wget "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-$ARCH.AppImage" -O appimagetool
+chmod +x ./appimagetool
+./appimagetool --comp zstd \
+	--mksquashfs-opt -Xcompression-level --mksquashfs-opt 22 \
+	-n "$out"/LibreSprite "$out"/"$APP"-anylinux-"$ARCH".AppImage

--- a/package_linux.sh
+++ b/package_linux.sh
@@ -1,61 +1,28 @@
 #!/bin/sh
 
-add()
-{
-  echo "adding $1"
-
-  if [ -e "/usr/lib/x86_64-linux-gnu/$1" ]; then
-      src="/usr/lib/x86_64-linux-gnu"
-  elif [ -e "/usr/lib/x86_64-linux-gnu/pulseaudio/$1" ]; then
-      src="/usr/lib/x86_64-linux-gnu/pulseaudio"
-  elif [ -e "/usr/lib64/$1" ]; then
-      src="/usr/lib64"
-  fi
-
-  if [ $src != $out ]; then
-      cp "$src/$1" "$out/$1"
-  fi
-
-  dependencies=$(readelf -d "$src/$1" | grep NEEDED | sed -En "s/[^\[]*\[([^]]*)\S*/\1/gp")
-
-  for dependency in $dependencies
-  do
-    if [ ! -f "$out/$dependency" ]; then
-        add $dependency
-    fi
-  done
-}
 
 out=$(pwd)
 src=$(pwd)
 
-add "libresprite"
-
-cp /usr/lib/libpthread.so* ./
-cp /usr/lib/librt.so* ./
-cp /usr/lib/libstdc++.so* ./
-
-rm libc.so*
-rm libm.so*
-
 chmod +x libresprite
 
-mkdir LibreSprite
-mkdir LibreSprite/usr
-mkdir LibreSprite/usr/bin
-mkdir LibreSprite/usr/lib
+mkdir -p LibreSprite
 
 mv ../../desktop/libresprite.desktop LibreSprite/
 cp ../../desktop/icons/hicolor/256x256/apps/libresprite.png LibreSprite/libresprite.png
 
-mv libresprite LibreSprite/usr/bin
-mv data LibreSprite/usr/bin
-mv *.so* LibreSprite/usr/lib
-
-wget https://github.com/AppImage/AppImageKit/releases/download/13/AppRun-x86_64 -O LibreSprite/AppRun
-chmod +x LibreSprite/AppRun
-
-wget https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-x86_64.AppImage -O appimagetool
-chmod +x appimagetool
-
-./appimagetool LibreSprite
+# Create AppImage with lib4bin and Sharun
+(
+export ARCH="$(uname -m)" # Just to be double sure
+cd LibreSprite
+wget "https://raw.githubusercontent.com/VHSgunzo/sharun/refs/heads/main/lib4bin" -O ./lib4bin
+chmod +x ./lib4bin
+xvfb-run -a -- ./lib4bin -p -v -e -r -k -w \
+  /usr/bin/libresprite \
+  /usr/bin/data \
+  /usr/lib/libpthread.so* \
+  /usr/lib/librt.so* \
+  /usr/lib/libstdc++.so* 
+ln ./sharun ./AppRun 
+./sharun -g
+)


### PR DESCRIPTION
<!-- be sure to check the copyright year of every file you've modified, and
in case, update it -->

Add compact, short information about your PR for easier understanding:

- Goal of the PR
- How does the PR work?
- Does it resolve any reported issue?
- If not a bug fix, why is this PR needed? What usecases does it solve?

This PR aims to adapt the package script to leverage sharun and AppImageTool to make it easier to build modern AppImages. I hope this also makes it easier for the project to distribute aarch64 binaries now as github actions is allowing aarch64 linux runners.

Because this automatically packages everything the app calls during runtime, I have also removed the add function, and let the lib4bin/sharun tools take over for that.

## How to test
<!-- Example code or instructions -->
Use my testing build from:
https://github.com/sounddrill31/LibreSprite/releases/tag/13608364921
(x86_64)
## Screenshots
![image](https://github.com/user-attachments/assets/195ebc14-caa0-4f4d-a00a-b445d4852ab9)

Screenshot on my personal OpenSUSE tumbleweed laptop
- Also tested on "AliceLinux", a from-scratch musl distro