### PR TITLE
Change duplicate keybind

### DIFF
--- a/data/gui.xml
+++ b/data/gui.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Aseprite    | Copyright (C) 2001-2016  David Capello -->
-<!-- LibreSprite | Copyright (C) 2017-2021  LibreSprite contributors -->
+<!-- LibreSprite | Copyright (C) 2017-2025  LibreSprite contributors -->
 <gui version="1.2-dev">
   <!-- Keyboard shortcuts -->
   <keyboard version="1">

--- a/data/gui.xml
+++ b/data/gui.xml
@@ -82,7 +82,7 @@
       <key command="NewFrame" shortcut="Alt+Shift+D">
         <param name="content" value="cel" />
       </key>
-      <key command="RemoveFrame" shortcut="Alt+C" />
+      <key command="RemoveFrame" shortcut="Alt+Shift+C" />
       <key command="FrameProperties" shortcut="P">
         <param name="frame" value="current" />
       </key>


### PR DESCRIPTION
<!-- be sure to check the copyright year of every file you've modified, and
in case, update it -->

Add compact, short information about your PR for easier understanding:

- Goal of the PR
Remove duplicate `Alt+C` keyboard shortcut.
- How does the PR work?
Changes default keyboard shortcut to remove frame from `Alt+C` to `Alt+Shift+C`. `Alt+C` conflicted with the window menu's shortcut for the Scripts menu. - I have checked and `Alt+Shift+C` is not assigned in the `gui.xml` file.
- Does it resolve any reported issue?
#528 

## How to test
<!-- Example code or instructions -->
Compile > Open > `Alt+N` - frame added > `Alt+C` - frame removed -- et voila