### PR TITLE
Remove rpath patch in AppImage

### DIFF
--- a/package_linux.sh
+++ b/package_linux.sh
@@ -21,7 +21,7 @@ export ARCH="$(uname -m)" # Just to be double sure
 cd LibreSprite
 wget "https://raw.githubusercontent.com/VHSgunzo/sharun/refs/heads/main/lib4bin" -O ./lib4bin
 chmod +x ./lib4bin
-xvfb-run -a -- ./lib4bin -p -v -e -r -k -w \
+xvfb-run -a -- ./lib4bin -p -v -e -k -w \
   ../libresprite \
   /usr/lib/libpthread.so* \
   /usr/lib/librt.so* \


### PR DESCRIPTION
This is not needed and can break libs, it usually breaks hardware acceleration with nvidia users and also causes assertion errors with gtk3. 

See: 

https://github.com/pkgforge-dev/Pixelpulse2-AppImage/pull/5
https://github.com/Rosalie241/RMG/pull/345


# How to test
Just launch the AppImage, ideally on a distro that is usually incompatible like a musl based one. 
