### PR TITLE
closing child window if it's unreachable

### DIFF
--- a/src/ui/window.cpp
+++ b/src/ui/window.cpp
@@ -464,6 +464,12 @@ void Window::onPaint(PaintEvent& ev)
 void Window::onBroadcastMouseMessage(WidgetsList& targets)
 {
   targets.push_back(this);
+  // Verifying if the child is still in the main window, and if not closing it.
+  gfx::Rect pos = bounds();
+  gfx::Rect cpos = childrenBounds();
+  if (cpos.x + cpos.w < 0 || cpos.x > pos.w || cpos.y + cpos.h < 0 || cpos.y > pos.h){
+    closeWindow(NULL);
+  }
 
   // Continue sending the message to siblings windows until a desktop
   // or foreground window.


### PR DESCRIPTION
- Check regularly if a child window, for example the file picker window, is reachable, and if it's out of reach closes it
- I just compare the size and position of the child window compared to the main one
- Solves issue #493 

## How to test
Open the file picker and drag it off the view, then try to do anything in the main window
