### PR TITLE
Add libXi-devel to Fedora dependencies

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -59,7 +59,7 @@ Debian/Ubuntu:
 
 Fedora:
 
-    sudo dnf install g++ cmake libcurl-devel freetype-devel giflib-devel gtest-devel libjpeg-devel pixman-devel libpng-devel SDL2-devel SDL2_image-devel tinyxml2-devel zlib-devel ninja-build nodejs-devel libarchive-devel
+    sudo dnf install g++ cmake libcurl-devel freetype-devel giflib-devel gtest-devel libjpeg-devel pixman-devel libpng-devel SDL2-devel SDL2_image-devel tinyxml2-devel zlib-devel ninja-build nodejs-devel libarchive-devel libXi-devel
 
 ### Windows dependencies
 


### PR DESCRIPTION
Without libXi-devel the following error is encountered when compiling on Fedora 42 x86_64:

```
user@localhost:~/LibreSprite/build$ ninja libresprite
[32/766] Building CXX object
src/she/CMakeFiles/she.dir/sdl2/sdl2_display.cpp.o
FAILED: src/she/CMakeFiles/she.dir/sdl2/sdl2_display.cpp.o
/usr/bin/c++ -DHAVE_CONFIG_H -DNDEBUG -DUSE_SDL2_BACKEND
-I/home/user/LibreSprite/third_party/qoi -I/usr/include/webp
-I/usr/include/pixman-1 -I/usr/include/freetype2
-I/home/user/LibreSprite/third_party/simpleini -I/usr/include/SDL2
-I/usr/include/rav1e -I/usr/include/svt-av1 -I/usr/include/libvmaf
-I/home/user/LibreSprite/src/. -I/home/user/LibreSprite/src/..
-I/home/user/LibreSprite/src/../third_party
-I/home/user/LibreSprite/src/../third_party/observable
-I/home/user/LibreSprite/build/src/base
-I/home/user/LibreSprite/third_party/EasyTab
-I/home/user/LibreSprite/third_party/observable/. -O3 -Wall -Wno-switch
-O2 -O2 -g -DNDEBUG -std=c++20 -D_GNU_SOURCE=1 -D_REENTRANT -MD -MT
src/she/CMakeFiles/she.dir/sdl2/sdl2_display.cpp.o -MF
src/she/CMakeFiles/she.dir/sdl2/sdl2_display.cpp.o.d -o
src/she/CMakeFiles/she.dir/sdl2/sdl2_display.cpp.o -c
/home/user/LibreSprite/src/she/sdl2/sdl2_display.cpp
In file included from
/home/user/LibreSprite/src/./she/sdl2/sdl2_display.h:12,
from
/home/user/LibreSprite/src/she/sdl2/sdl2_display.cpp:23:
/home/user/LibreSprite/src/../third_party/EasyTab/easytab.h:160:10:
fatal error: X11/extensions/XInput.h: No such file or directory
  160 | #include <X11/extensions/XInput.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
[34/766] Building CXX object
src/she/CMakeFiles/she.dir/sdl2/sdl2_surface.cpp.o
FAILED: src/she/CMakeFiles/she.dir/sdl2/sdl2_surface.cpp.o
/usr/bin/c++ -DHAVE_CONFIG_H -DNDEBUG -DUSE_SDL2_BACKEND
-I/home/user/LibreSprite/third_party/qoi -I/usr/include/webp
-I/usr/include/pixman-1 -I/usr/include/freetype2
-I/home/user/LibreSprite/third_party/simpleini -I/usr/include/SDL2
-I/usr/include/rav1e -I/usr/include/svt-av1 -I/usr/include/libvmaf
-I/home/user/LibreSprite/src/. -I/home/user/LibreSprite/src/..
-I/home/user/LibreSprite/src/../third_party
-I/home/user/LibreSprite/src/../third_party/observable
-I/home/user/LibreSprite/build/src/base
-I/home/user/LibreSprite/third_party/EasyTab
-I/home/user/LibreSprite/third_party/observable/. -O3 -Wall -Wno-switch
-O2 -O2 -g -DNDEBUG -std=c++20 -D_GNU_SOURCE=1 -D_REENTRANT -MD -MT
src/she/CMakeFiles/she.dir/sdl2/sdl2_surface.cpp.o -MF
src/she/CMakeFiles/she.dir/sdl2/sdl2_surface.cpp.o.d -o
src/she/CMakeFiles/she.dir/sdl2/sdl2_surface.cpp.o -c
/home/user/LibreSprite/src/she/sdl2/sdl2_surface.cpp
In file included from
/home/user/LibreSprite/src/./she/sdl2/sdl2_display.h:12,
from
/home/user/LibreSprite/src/./she/sdl2/sdl2_surface.h:13,
from
/home/user/LibreSprite/src/she/sdl2/sdl2_surface.cpp:11:
/home/user/LibreSprite/src/../third_party/EasyTab/easytab.h:160:10:
fatal error: X11/extensions/XInput.h: No such file or directory
  160 | #include <X11/extensions/XInput.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
[36/766] Building CXX object src/she/CMakeFiles/she.dir/sdl2/she.cpp.o
FAILED: src/she/CMakeFiles/she.dir/sdl2/she.cpp.o
/usr/bin/c++ -DHAVE_CONFIG_H -DNDEBUG -DUSE_SDL2_BACKEND
-I/home/user/LibreSprite/third_party/qoi -I/usr/include/webp
-I/usr/include/pixman-1 -I/usr/include/freetype2
-I/home/user/LibreSprite/third_party/simpleini -I/usr/include/SDL2
-I/usr/include/rav1e -I/usr/include/svt-av1 -I/usr/include/libvmaf
-I/home/user/LibreSprite/src/. -I/home/user/LibreSprite/src/..
-I/home/user/LibreSprite/src/../third_party
-I/home/user/LibreSprite/src/../third_party/observable
-I/home/user/LibreSprite/build/src/base
-I/home/user/LibreSprite/third_party/EasyTab
-I/home/user/LibreSprite/third_party/observable/. -O3 -Wall -Wno-switch
-O2 -O2 -g -DNDEBUG -std=c++20 -D_GNU_SOURCE=1 -D_REENTRANT -MD -MT
src/she/CMakeFiles/she.dir/sdl2/she.cpp.o -MF
src/she/CMakeFiles/she.dir/sdl2/she.cpp.o.d -o
src/she/CMakeFiles/she.dir/sdl2/she.cpp.o -c
/home/user/LibreSprite/src/she/sdl2/she.cpp
In file included from
/home/user/LibreSprite/src/./she/sdl2/sdl2_display.h:12,
                 from /home/user/LibreSprite/src/she/sdl2/she.cpp:16:
/home/user/LibreSprite/src/../third_party/EasyTab/easytab.h:160:10:
fatal error: X11/extensions/XInput.h: No such file or directory
  160 | #include <X11/extensions/XInput.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
[49/766] Building CXX object
src/she/CMakeFiles/she.dir/common/freetype_font.cpp.o
ninja: build stopped: subcommand failed.
```

<!-- be sure to check the copyright year of every file you've modified, and
in case, update it -->

Add compact, short information about your PR for easier understanding:

- Goal of the PR
- How does the PR work?
- Does it resolve any reported issue?
- If not a bug fix, why is this PR needed? What usecases does it solve?

## How to test
<!-- Example code or instructions -->
