### PR TITLE
Update pipeline for MSYS2 (UCRT64)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -63,9 +63,9 @@ Fedora:
 
 ### Windows dependencies
 
-To install the required dependencies with msys2, run the following in mingw32:
+To install the required dependencies with MSYS2, run the following in ucrt64.exe:
 
-    pacman -S base-devel mingw-w64-i686-gcc mingw-w64-i686-cmake mingw-w64-i686-make mingw-w64-i686-curl mingw-w64-i686-freetype mingw-w64-i686-giflib mingw-w64-i686-libjpeg-turbo mingw-w64-i686-libpng mingw-w64-i686-libwebp mingw-w64-i686-pixman mingw-w64-i686-SDL2 mingw-w64-i686-SDL2_image mingw-w64-i686-tinyxml2 mingw-w64-i686-v8 mingw-w64-i686-zlib mingw-w64-i686-libarchive
+    pacman -S base-devel mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-cmake mingw-w64-ucrt-x86_64-make mingw-w64-ucrt-x86_64-curl mingw-w64-ucrt-x86_64-freetype mingw-w64-ucrt-x86_64-giflib mingw-w64-ucrt-x86_64-libjpeg-turbo mingw-w64-ucrt-x86_64-libpng mingw-w64-ucrt-x86_64-libwebp mingw-w64-ucrt-x86_64-pixman mingw-w64-ucrt-x86_64-SDL2 mingw-w64-ucrt-x86_64-SDL2_image mingw-w64-ucrt-x86_64-tinyxml2 mingw-w64-ucrt-x86_64-v8 mingw-w64-ucrt-x86_64-zlib mingw-w64-ucrt-x86_64-libarchive
 
 ### MacOS dependencies
 
@@ -92,14 +92,15 @@ and recompile.
 
 To compile LibreSprite, run the following commands:
 
-    cmake -G Ninja ..
+    cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -G Ninja ..
     ninja libresprite
 
 ### Windows details
 
-Run the following in mingw32.exe:
+To compile LibreSprite, run the following in ucrt64.exe:
 
-    cmake -G Ninja ..
+    cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -G Ninja ..
+    ninja libresprite
 
 ### MacOS details
 
@@ -107,6 +108,7 @@ To compile LibreSprite, run the following commands:
 ```
     cmake \
       -DCMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk \
+      -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
       -G Ninja \
       ..
     ninja libresprite
@@ -122,7 +124,15 @@ LibreSprite for Android.
 
 ## Installing
 
+### Linux details
+
 Once you've finished compiling, you can install LibreSprite by running the
 following command from the `build` directory:
 
     ninja install
+
+### Windows details
+
+Windows build links against the libraries used by MSYS2, so to make the application runnable outside of MSYS2 (by simply double-clicking libresprite.exe in Windows), go back to the main project directory and run the packaging script:
+
+    ./package_win.sh

--- a/package_win.sh
+++ b/package_win.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# --- Configuration ---
+EXE="${1:-build/bin/libresprite.exe}"
+DEST_DIR="$(dirname "$EXE")"
+
+# Ensure executable exists
+if [[ ! -f "$EXE" ]]; then
+  echo "ERROR: Executable not found: $EXE" >&2
+  exit 1
+fi
+
+MSYS_ROOT="/ucrt64"
+
+ldd "$EXE" | grep -iE '/ucrt64/' | while IFS= read -r line; do
+  # Extract the path between '=>' and '('
+  libpath=$(echo "$line" | sed -nE 's/.*=>[[:space:]]*([^[:space:]]+)[[:space:]]*\(.*/\1/p')
+  
+  if [[ -f "$libpath" ]]; then
+    cp -u "$libpath" "$DEST_DIR"/
+  else
+    echo "ERROR: Missing file: $libpath"
+  fi
+done

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Aseprite     | Copyright (C) 2001-2016  David Capello
-# LibreSprite  | Copyright (C)      2021  LibreSprite contributors
+# LibreSprite  | Copyright (C) 2021-2025  LibreSprite contributors
 
 ######################################################################
 # Common definitions for all Aseprite libraries/projects
@@ -28,6 +28,12 @@ include_directories(. .. ../third_party ../third_party/observable)
 if((UNIX AND NOT APPLE) OR (WIN32 AND NOT MSVC))
   set(KEEP_INJECTIONS_BEGIN "-Wl,--whole-archive")
   set(KEEP_INJECTIONS_END "-Wl,--no-whole-archive")
+
+  # Required for compiling with gcc/g++ under MSYS2 UCRT64
+  add_compile_options(
+    "$<$<COMPILE_LANGUAGE:CXX>:-include;cstdint>"
+    "$<$<COMPILE_LANGUAGE:C>:-include;stdint.h>"
+  )
 endif()
 
 if(APPLE)


### PR DESCRIPTION
Building under Windows with mingw32 fails since the `SDL2_image`, `tinyxml2`, and `v8` libraries have dropped support for 32-bit.
<img width="1120" height="324" alt="obraz" src="https://github.com/user-attachments/assets/d720da47-fca4-47b6-b25c-c619bce8015c" />

The solution would be to use either mingw64 or ucrt64 equivalents.
Since UCRT is a more modern standard library used by Microsoft Visual Studio by default, I opted to go with that one.
It should work and behave as if the code was compiled with MSVC, ensuring better compatibility with MSVC, both at build time and at run time.

What has been done in the PR:
- Update INSTALL.md with the instructions for UCRT64 (included the -DCMAKE_POLICY_VERSION_MINIMUM=3.5 flag for building with CMake 4.x)
- Add a packaging script for MSYS2 libraries to make user's life easier
- Update src/CMakeLists.txt to include stdint on any non-unix gcc pipeline (otherwise it fails on any usage of types like `int32_t`, `uint32_t`, `size_t` etc. under gcc on Windows, despite the C++20 standard being forced)
