### PR TITLE
Add code signing to DMG creation step

### DIFF
--- a/.github/workflows/cmakeMacOs.yml
+++ b/.github/workflows/cmakeMacOs.yml
@@ -95,6 +95,7 @@ jobs:
 
     - name: Create DMG
       run: |
+        codesign --force --deep -s - ./bundle/libresprite.app
         hdiutil create -volname "LibreSprite" -srcfolder bundle -ov -format UDZO "libresprite.dmg"
 
     - name: Upload Artifacts


### PR DESCRIPTION


- Adding self codesigning to the macOS build action to avoid the "this app is damaged" notification, rendering the application useless. 
- Adds a line to the dmg creation action that forces a deep codesign replacement with a working self signed certificate, making it runnable on arm macOS
- Tested on my own machine, as well as several others, and several other people also tested it. Solves the "this app is damaged" notification on arm macOS that renders the application useless.
