### PR TITLE
Enable WebP support in build instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -106,7 +106,7 @@ Run the following in mingw32.exe:
 To compile LibreSprite, run the following commands:
 ```
     cmake \
-      -DCMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk \
+      -DCMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk -DWITH_WEBP_SUPPORT=ON \
       -G Ninja \
       ..
     ninja libresprite


### PR DESCRIPTION
Added flag for cmake to enable webp support when building, letting the user avoid the webpdecoder is missing error when building