### PR TITLE
Fix typo in Theming section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ As LibreSprite has a newly budding community, we need help building the infrastr
 Don't worry, it isn't as hard as you might think! Just follow the instructions [here](INSTALL.md).
 
 ## Theming
-Don't like the default look of Libresprite? Don't panic, you can download from the Libresprite [resources](https://libresprite.github.io/#!/resources) repo. 
+Don't like the default look of LibreSprite? Don't panic, you can download from the LibreSprite [resources](https://libresprite.github.io/#!/resources) repo. 
 
 ## License
 This program is distributed under the [GNU General Public License Version 2](LICENSE.txt).


### PR DESCRIPTION
Fixed the inconsistencies of the word "LibreSprite" in the "Theming" section to match the rest of the README
