### PR TITLE
Fix macos build by properly linking homebrew WebP libraries

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -105,11 +105,12 @@ Run the following in mingw32.exe:
 
 To compile LibreSprite, run the following commands:
 ```
-    cmake \
-      -DCMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk \
-      -G Ninja \
-      ..
-    ninja libresprite
+    export LDFLAGS="-L/opt/homebrew/lib $LDFLAGS"
+    export CPPFLAGS="-I/opt/homebrew/include $CPPFLAGS"
+
+    ARCH=$(uname -m) # arm64 or x86_64
+
+    cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=$ARCH
 ```
 ### Android details
 


### PR DESCRIPTION
Fixes build failure on macOS due to 'libwebp/libwebpdecoder' not being found during linking

the problem was Homebrew uses the different path on silicon macos and intel.

We can avoid hardcoded path by usin environment variables (the CPPFLAGS and LDFLAGS) to point CMake and the linker to Homebrew-installed WebP headers and libraries. I tweaked the build configuration to include these vars but i think it's best if someone can modify the CMakeLists file to automatically detect ARM macOS and add these paths. 

It fixes the ld: library 'webpdecoder' not found error reported in [https://github.com/LibreSprite/LibreSprite/issues/574](url)
