### PR TITLE
Add automated macOS build script and update installation docs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,3 +1,5 @@
+<!-- Copyright (C) 2026  LibreSprite contributors -->
+
 # Installation
 
 ## Table of contents

--- a/build_libresprite_macos.sh
+++ b/build_libresprite_macos.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Copyright (C) 2026  LibreSprite contributors
 
 set -e  # Exit immediately on error
 


### PR DESCRIPTION
This pull request improves the macOS installation experience for LibreSprite by introducing an automated build script and updating the documentation to make building on macOS much easier. The new script streamlines dependency installation, repository setup, and the build process, while the documentation now clearly explains both automated and manual build options.

**Documentation improvements:**

* Updated `INSTALL.md` to highlight the new automated build script for macOS, providing clear instructions for both quick (automated) and manual builds. [[1]](diffhunk://#diff-09b140a43ebfdd8dbec31ce72cafffd15164d2860fd390692a030bcb932b54a0L14-R16) [[2]](diffhunk://#diff-09b140a43ebfdd8dbec31ce72cafffd15164d2860fd390692a030bcb932b54a0L106-R125)
* Added copyright notice to `INSTALL.md`.

**Build automation:**

* Added new `build_libresprite_macos.sh` script that:
  - Checks for Homebrew and essential tools
  - Installs all required dependencies via Homebrew
  - Clones or updates the LibreSprite repository
  - Configures and builds the project using CMake and Ninja
  - Provides clear user feedback and error handling
