### PR TITLE
Fix high CPU usage and UI lag on Linux by introducing frame-limited redraw

### DIFF
--- a/src/app/commands/cmd_undo.cpp
+++ b/src/app/commands/cmd_undo.cpp
@@ -1,5 +1,5 @@
-// Aseprite
-// Copyright (C) 2001-2015  David Capello
+// Aseprite    | Copyright (C) 2001-2015  David Capello
+// LibreSprite | Copyright (C) 2016-2026  LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as
@@ -88,7 +88,7 @@ void UndoCommand::onExecute(Context* context)
       current_editor->drawSpriteClipped(
         gfx::Region(gfx::Rect(0, 0, sprite->width(), sprite->height())));
 
-      current_editor->manager()->flipDisplay();
+      current_editor->manager()->requestRedraw();
       base::this_thread::sleep_for(0.01);
     }
   }

--- a/src/app/ui/editor/editor.cpp
+++ b/src/app/ui/editor/editor.cpp
@@ -1,5 +1,5 @@
 // Aseprite    | Copyright (C) 2001-2016  David Capello
-// LibreSprite | Copyright (C) 2021       LibreSprite contributors
+// LibreSprite | Copyright (C) 2021-2026  LibreSprite contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 2 as
@@ -865,7 +865,7 @@ void Editor::flashCurrentLayer()
       m_document->setExtraCel(extraCel);
       drawSpriteClipped(gfx::Region(
                           gfx::Rect(0, 0, m_sprite->width(), m_sprite->height())));
-      manager()->flipDisplay();
+      manager()->requestRedraw();
       m_document->setExtraCel(oldExtraCel);
     }
 

--- a/src/she/sdl2/she.cpp
+++ b/src/she/sdl2/she.cpp
@@ -1,5 +1,5 @@
 // SHE library
-// Copyright (C) 2021 LibreSprite contributors
+// Copyright (C) 2021-2026 LibreSprite contributors
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -446,6 +446,15 @@ namespace she {
             Event ev;
             ev.setType(Event::MouseEnter);
             m_events.push(ev);
+          }
+
+          // Drain excess SDL_MOUSEMOTION events, keeping only the most recent
+          {
+            SDL_Event nextEvent;
+            while (SDL_PeepEvents(&nextEvent, 1, SDL_GETEVENT, SDL_MOUSEMOTION, SDL_MOUSEMOTION) > 0) {
+              // Use the newer event, discarding the current one
+              sdlEvent = nextEvent;
+            }
           }
 
           event.setType(Event::MouseMove);

--- a/src/she/sdl2/she.cpp
+++ b/src/she/sdl2/she.cpp
@@ -448,12 +448,14 @@ namespace she {
             m_events.push(ev);
           }
 
-          // Drain excess SDL_MOUSEMOTION events, keeping only the most recent
+          // Drain excess SDL_MOUSEMOTION and SDL_FINGERMOTION events, keeping only the most recent
           {
             SDL_Event nextEvent;
             while (SDL_PeepEvents(&nextEvent, 1, SDL_GETEVENT, SDL_MOUSEMOTION, SDL_MOUSEMOTION) > 0) {
-              // Use the newer event, discarding the current one
               sdlEvent = nextEvent;
+            }
+            while (SDL_PeepEvents(&nextEvent, 1, SDL_GETEVENT, SDL_FINGERMOTION, SDL_FINGERMOTION) > 0) {
+              penPressure = std::max(nextEvent.tfinger.pressure, 0.0001f);
             }
           }
 

--- a/src/ui/manager.h
+++ b/src/ui/manager.h
@@ -1,5 +1,6 @@
-// Aseprite UI Library
-// Copyright (C) 2001-2016  David Capello
+// UI Library
+// Aseprite    | Copyright (C) 2001-2016  David Capello
+// LibreSprite | Copyright (C) 2016-2026  LibreSprite contributors
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -42,6 +43,9 @@ namespace ui {
 
     // Refreshes the real display with the UI content.
     void flipDisplay();
+
+    // Request a redraw on the next frame
+    void requestRedraw() { m_redrawRequested = true; }
 
     // Returns true if there are messages in the queue to be
     // distpatched through jmanager_dispatch_messages().
@@ -96,6 +100,12 @@ namespace ui {
     void addInvalidRegion(const gfx::Region& b) {
       m_invalidRegion |= b;
     }
+
+    // Check if a redraw was requested
+    bool isRedrawRequested() const { return m_redrawRequested; }
+    
+    // Get the dirty region
+    const gfx::Region& getDirtyRegion() const { return m_dirtyRegion; }
 
     // Mark the given rectangle as a area to be flipped to the real
     // screen
@@ -179,6 +189,11 @@ namespace ui {
 
     // Current pressed buttons.
     MouseButtons m_mouseButtons;
+
+    // Frame-limited redraw mechanism
+    bool m_redrawRequested;
+    double m_lastFlipTime;
+    static constexpr double MIN_FRAME_INTERVAL = 1.0 / 120.0; // 120 FPS max
   };
 
 } // namespace ui

--- a/src/ui/manager.h
+++ b/src/ui/manager.h
@@ -103,7 +103,7 @@ namespace ui {
 
     // Check if a redraw was requested
     bool isRedrawRequested() const { return m_redrawRequested; }
-    
+
     // Get the dirty region
     const gfx::Region& getDirtyRegion() const { return m_dirtyRegion; }
 
@@ -193,7 +193,7 @@ namespace ui {
     // Frame-limited redraw mechanism
     bool m_redrawRequested;
     double m_lastFlipTime;
-    static constexpr double MIN_FRAME_INTERVAL = 1.0 / 120.0; // 120 FPS max
+    static constexpr double MIN_FRAME_INTERVAL = 1.0 / 720.0; // 720 FPS max
   };
 
 } // namespace ui

--- a/src/ui/message_loop.cpp
+++ b/src/ui/message_loop.cpp
@@ -1,5 +1,6 @@
-// Aseprite UI Library
-// Copyright (C) 2001-2013  David Capello
+// UI Library
+// Aseprite    | Copyright (C) 2001-2013  David Capello
+// LibreSprite | Copyright (C) 2016-2026  LibreSprite contributors
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -27,6 +28,12 @@ void MessageLoop::pumpMessages()
   } else {
     m_manager->collectGarbage();
   }
+  
+  // Call flipDisplay from the central location if a redraw was requested
+  if (m_manager->isRedrawRequested() || !m_manager->getDirtyRegion().isEmpty()) {
+    m_manager->flipDisplay();
+  }
+  
   she::instance()->sleep();
 }
 


### PR DESCRIPTION
Pull request addresses a performance issue on Linux reported by users on Discord where LibreSprite would saturate a single CPU core and become laggy or unresponsive during continuous drawing operations (e.g., freehand or line tools).

The initial performance issue has been primarily observed on Arch-based distributions with hardware configurations including both `nVidia RTX 3xxx` and integrated `Intel HD` GPUs.

On affected Linux distributions, mouse motion and input events can be delivered at very high frequency. The existing redraw logic triggered full redraw work on every such event, which caused excessive computation and prevented the UI from remaining responsive.

This behaviour was not observed on Windows or macOS (and maybe some other Linux configurations) primarily because the graphics drivers and system compositors on those platforms enforce frame pacing and GPU acceleration more aggressively, effectively hiding the unbounded redraw storm.

The core problem stems from:
- Rendering and overlay updates being performed immediately on every incoming event
- Dirty regions being applied individually in a loop without coalescing into a single region
- No frame pacing enforced, leading to continuous heavy work even when the display update rate was higher than needed

What was done:
- A frame limiter with a cap of 720Hz (as a good common multiply of 60, 120 and 144) was introduced to ensure that redraw work only occurs at a reasonable rate, preventing input flood overloading on Linux.
- Every frame any excess `SDL_MOUSEMOTION` events are drained, keeping only the most recent one, reducing redundant work.
- Added a `requestRedraw()` method to centralise redraw requests instead of calling `flipDisplay()` directly from multiple event handlers, potentially at the same time.
- Dirty regions are merged into a single bounding rectangle, simplifying and reducing the workload performed per frame flip.

The code was tested on Archlinux, Windows 11 and macOS 26.2 (Tahoe), and confirmed to work correctly with the new logic in place.


Here's how the application behaved no Arch before the fix (take note of the stuttering during drawing actions and the C2/C8 cores utilization during frequent redraws):

https://github.com/user-attachments/assets/4f4dffa5-2872-4538-9c3f-a2cb47910c15

And here's the performance after the fix has been applied, no visible stutter visible and no CPU hogging that leads to application unresponsiveness:

https://github.com/user-attachments/assets/8e2afb0b-aeda-4ada-a69b-a6c6cf70c6a8