### PR TITLE
Add support for slower V8 initialization without the snapshot blob

### DIFF
--- a/.github/workflows/cmakeWin64.yml
+++ b/.github/workflows/cmakeWin64.yml
@@ -50,7 +50,6 @@ jobs:
         cd ..
         rm build/bin/gen.exe
         node package_win.js build/bin/libresprite.exe
-        # cp /mingw64/bin/snapshot_blob.bin ./build/bin
     - name: Archive production artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/src/script/v8/engine.cpp
+++ b/src/script/v8/engine.cpp
@@ -1,5 +1,5 @@
 // LibreSprite Scripting Library
-// Copyright (C) 2021  LibreSprite contributors
+// Copyright (C) 2021-2026  LibreSprite contributors
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -68,8 +68,12 @@ public:
       if (rf.findFirst()) {
 	v8::V8::InitializeExternalStartupData(rf.filename().c_str());
       } else {
-	v8::V8::InitializeICU();
+	// When snapshot_blob.bin is not available, try to initialize from default location
+	// If that fails, V8 will use slower initialization without snapshot
+	v8::V8::InitializeExternalStartupData(nullptr);
       }
+      
+      v8::V8::InitializeICU();
 
       m_platform = v8::platform::NewDefaultPlatform();
       v8::V8::InitializePlatform(m_platform.get());


### PR DESCRIPTION
Fixes V8 handling logic when `snapshot_blob.bin` is not available.
Previously, the code always assumed the snapshot would be present and attempted to initialize ICU (international components) immediately if finding the snapshot failed, which led to application crashing when attempted to load any JS plugin.
With this change, the engine instead first tries to initialize V8 using the external startup data API with a `nullptr`, which instructs V8 to fall back to the slower internal initialization path when no snapshot blob is found.

On my PC setup (Windows 11, i7 6800K, 32 GB DDR4, RTX 3080) the startup of `v1.2-dev` release build without the `snapshot_blob.bin` takes about 4 seconds since window creation for the app to load the UI as opposed to almost immediate launch with the official `v1.1` build, which is not that terrible of a drawback when the better option is not provided.