### PR TITLE
Fix wrong font license copyrights

### DIFF
--- a/data/fonts/OFL.txt
+++ b/data/fonts/OFL.txt
@@ -1,4 +1,4 @@
-Copyright 2014-2021 Adobe (http://www.adobe.com/), with Reserved Font Name 'Source'
+Copyright 2022 The Noto Project Authors (https://github.com/notofonts)
 
 This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:


### PR DESCRIPTION
I don't know why the license copyright preamble text is for the Source Sans font family instead of Noto Sans.
This patch fixes that.
