### PR TITLE
Add path pre-verification before saving

### DIFF
--- a/src/app/ui/file_selector.cpp
+++ b/src/app/ui/file_selector.cpp
@@ -547,19 +547,17 @@ again:
     }
     // else file-name specified in the entry is really a file to open...
 
-#ifdef _WIN32
     if (m_type == FileSelectorType::Save) {
       std::string finalFilename = base::get_file_name(buf);
-      std::string fver = base::win32_verify_filename(finalFilename);
-      if (!fver.empty())
+      if (const size_t fver = base::verify_filename(finalFilename); fver != std::string::npos)
       {
-        Alert::show("Error<<Invalid filename: \"%s\"<<%s||&Go back", finalFilename.c_str(), fver.c_str());
+        Alert::show("Error<<Invalid filename: \"%s\"<<The name contains an invalid '%c' character.||&Go back",
+          finalFilename.c_str(), finalFilename[fver]);
 
         setVisible(true);
         goto again;
       }
     }
-#endif
 
     // does it not have extension? ...we should add the extension
     // selected in the filetype combo-box
@@ -755,18 +753,16 @@ void FileSelector::onNewFolder()
     if (currentFolder) {
       std::string dirname = window.name()->text();
 
-#ifdef _WIN32
       if (m_type == FileSelectorType::Save) {
-        std::string fver = base::win32_verify_filename(dirname);
-        if (!fver.empty())
+        if (const size_t fver = base::verify_filename(dirname); fver != std::string::npos)
         {
-          Alert::show("Error<<Invalid folder name: \"%s\"<<%s||&OK", dirname.c_str(), fver.c_str());
+          Alert::show("Error<<Invalid folder name: \"%s\"<<The name contains an invalid '%c' character.||&OK",
+            dirname.c_str(), dirname[fver]);
 
           setVisible(true);
           return;
         }
       }
-#endif
 
       // Create the new directory
       try {

--- a/src/base/path.cpp
+++ b/src/base/path.cpp
@@ -244,21 +244,20 @@ int compare_filenames(const std::string& a, const std::string& b)
     return 1;
 }
 
-#ifdef _WIN32
-std::string win32_verify_filename(const std::string& filename)
+size_t verify_filename(const std::string& filename)
 {
+#ifdef _WIN32
   // In general, _wfopen() would fail for most of these characters *except slashes and colon*,
   // but returning a meaningful error message to the user is always a nice practice.
   const std::string invalidChars = ":?\"<>|*";
 
-  for (const char c : filename) {
-    if (invalidChars.find(c) != std::string::npos) {
-      return "The filename contains an invalid '"
-        + std::string(1,c) + "' character.";
+  for (size_t it=0; it<filename.size(); ++it) {
+    if (invalidChars.find(filename[it]) != std::string::npos) {
+      return it;
     }
   }
-  return {};
-}
 #endif
+  return std::string::npos;
+}
 
 } // namespace base

--- a/src/base/path.h
+++ b/src/base/path.h
@@ -53,10 +53,8 @@ namespace base {
 
   int compare_filenames(const std::string& a, const std::string& b);
 
-#ifdef _WIN32
-  // Does platform-specific filename pre-validation to avoid any unexpected edge-case
-  // behaviors caused by feeding garbage parameters to file APIs.
-  std::string win32_verify_filename(const std::string& filename);
-#endif
-
+  // Does platform-specific filename pre-validation to avoid any unexpected
+  // edge-case behaviors caused by feeding unsolicited parameters to stdio API
+  // (like ':' for addressing alternate NTFS streams on Windows)
+  size_t verify_filename(const std::string& filename);
 }


### PR DESCRIPTION
The issue reveals itself when trying to save a file on Windows that contains a colon `:` in it.
LibreSprite saves such file successfully, but the file appears to have a corrupted name (everything after colon in the filename is truncated) with no data in it.

We had a heated discussion on Discord about if it should be handled by application or by `fopen()` API, but after a long debugging session I found out Paths like `C:\Dir\File:whatever.txt` are valid inputs for `fopen()`.
<img width="2870" height="1505" alt="image2" src="https://github.com/user-attachments/assets/ec2dcf8a-0548-4c0f-b082-d7404338cf43" />

It turns out fopen() allows such input because of Alternate Data Streams functionality in NTFS that not many people are aware of:
> Alternate Data Streams (ADS) is a feature in the Windows operating system that allows data to be associated and hidden within files. An ADS can be used to store additional information about a file, such as metadata or comments, without changing the file itself.
> ADS is a feature that was introduced in the [New Technology File System (NTFS)](https://www.komprise.com/glossary_terms/ntfs-extended-attributes/) used by Windows, and it allows users to attach a second data stream to a file, which is invisible to most applications and users. The ADS is named using a colon, for example, “myfile.txt:ads.txt”.

Files saved in such way in LibreSprite present themselves as having 0B and only after listing them for streams it reveals there is a hidden data stream within them
<img width="1471" height="731" alt="image" src="https://github.com/user-attachments/assets/3356257d-08f7-4809-88b5-5a52615a73e6" />

Such functionality, while completely legit from the FileSystem's PoV is useless for our use case, and even more useless for the end users that will end up confused, thinking their files got broken, blaming it on LibreSprite.

While the issue only affects the `:` character and for every other prohibited characters in pathname fopen() returns an error and it is properly handled by LibreSprite, I don't consider the resulting error log to be providing the right info about what the user explicitly did wrong:
<img width="1405" height="1111" alt="err1" src="https://github.com/user-attachments/assets/fc377c5e-4777-4338-b0e8-e3fb5d855d73" />

This change provides a meaningful error dialog to the user if something is wrong with the filename:
<img width="1408" height="1116" alt="err2" src="https://github.com/user-attachments/assets/708d7b5b-9a48-443f-ab88-b30b82826a9c" />

In my opinion this solution is better from the point of view of user friendliness and code robustness (app should anticipate bad code paths and avoid them from happening instead of expecting an error and waiting for it to happen to be handled then).
You might want to include it, or not and just cover the colons. It's up to the maintainers' discretion.