### PR TITLE
Add SDL hints to disable pixel rescaling on hi-dpi screens under Windows

### DIFF
--- a/src/she/sdl2/she.cpp
+++ b/src/she/sdl2/she.cpp
@@ -1,5 +1,5 @@
 // SHE library
-// Copyright (C) 2021 LibreSprite contributors
+// Copyright (C) 2021-2026 LibreSprite contributors
 //
 // This file is released under the terms of the MIT license.
 // Read LICENSE.txt for more information.
@@ -21,10 +21,12 @@
 #undef HAVE_STDINT_H
 #if __has_include(<SDL2/SDL.h>)
 #include <SDL2/SDL.h>
+#include <SDL2/SDL_hints.h>
 #include <SDL2/SDL_image.h>
 #include <SDL2/SDL_syswm.h>
 #else
 #include <SDL.h>
+#include <SDL_hints.h>
 #include <SDL_image.h>
 #include <SDL_syswm.h>
 #endif
@@ -38,6 +40,8 @@
 #include <atomic>
 #include <chrono>
 #include <thread>
+
+#define SDL_HINT_WINDOWS_DPI_AWARENESS "SDL_WINDOWS_DPI_AWARENESS"
 
 float penPressure = 0;
 
@@ -943,11 +947,17 @@ namespace she {
 // It must be defined by the user program code.
 extern int app_main(int argc, char* argv[]);
 
-int main(int argc, char* argv[]) {
+int main(const int argc, char* argv[]) {
   #ifdef SDL_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR
   SDL_SetHint(SDL_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR, "0");
   #endif
   SDL_SetHint(SDL_HINT_VIDEO_ALLOW_SCREENSAVER, "1");
+
+  // If the requested DPI awareness is not available on the currently running OS,
+  // SDL will try to request the best available match.
+  // https://wiki.libsdl.org/SDL2/SDL_HINT_WINDOWS_DPI_AWARENESS
+  SDL_SetHint(SDL_HINT_WINDOWS_DPI_AWARENESS, "permonitorv2");
+
   if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS) != 0) {
     std::cerr << "Critical: Could not initialize SDL2. Aborting." << std::endl;
     return -1;


### PR DESCRIPTION
By default when rendering on Windows with DPI scaling, SDL2 window contents get resized according to OS scaling.
While this _could_ be an expected result in _some_ cases, for LibreSprite which UI style is pixel-ish, the app looks blurry when scaled by non-integer factors.

Here's an example of how it looks _now_ with 175% OS screen scaling (no additional scaling set in app):
<img width="1165" height="583" alt="bad-dpi" src="https://github.com/user-attachments/assets/903d47d5-079b-4c2e-9816-250011a6fa32" />

Here's how it looks _after_ applying the patch (no additional scaling set in app):
<img width="593" height="351" alt="good-dpi" src="https://github.com/user-attachments/assets/c4ea9132-e534-40d7-9d13-90915c16f386" />

The issue can be solved by setting an appropriate window hint before the video subsystem is initialized
https://wiki.libsdl.org/SDL2/SDL_HINT_WINDOWS_DPI_AWARENESS

SDL2 seems to handle properly Hi-DPI displays on macOS, and on Linux afaik LS doesn't use Wayland natively, so under X11/XWayland fractional scaling is not a thing anyway, so no additional changes are needed for those.