### PR TITLE
Fix for ui::Splitter Widget bug

### DIFF
--- a/src/ui/splitter.cpp
+++ b/src/ui/splitter.cpp
@@ -118,6 +118,7 @@ bool Splitter::onProcessMessage(Message* msg)
 
         limitPos();
         layout();
+        flushRedraw();
         return true;
       }
       break;


### PR DESCRIPTION
This PR fixes Splitter widget drawing issue, caused by not drawing
panel1 and panel2 (childrens of the Splitter widget) when trying to change split ratio rapidly.

How bug looks like:
https://github.com/user-attachments/assets/08110829-cecd-41f9-b648-779db0f2fae4
https://github.com/user-attachments/assets/568caeec-6b8a-4353-8323-02e8449aa26d

 - Platform: Windows 11
 - Build Type: Debug / Release
 - Hardware: AMD Ryzen 4000 Series with integrated Graphics

The bug is fixed by creating paintEvents for the splitter immidiatly after Invalidation, so that
events aren't lost somewhere along the way.
By using flushRedraw(), the bug disappears.


https://github.com/user-attachments/assets/d6760681-52ff-4cc7-8b61-3a030b5c78dc
https://github.com/user-attachments/assets/fb7ec874-cce5-48e9-977d-163dc28776f6



