### PR TITLE
Catch failure to save brushes

### DIFF
--- a/src/app/app_brushes.cpp
+++ b/src/app/app_brushes.cpp
@@ -180,7 +180,12 @@ AppBrushes::AppBrushes()
 
 AppBrushes::~AppBrushes()
 {
-  save(userBrushesFilename());
+  try {
+    save(userBrushesFilename());
+  }
+  catch (const std::exception& ex) {
+    LOG("Error saving user brushes: %s", ex.what());
+  }
 }
 
 AppBrushes::slot_id AppBrushes::addBrushSlot(const BrushSlot& brush)


### PR DESCRIPTION
This avoids getting "Aborted (Core dumped)" when closing LibreSprite when it is unable to write `user.aseprite-brushes`. Not sure about the log level, maybe it should be `WARNING` or `ERROR` instead?