### PR TITLE
Fix V8 script engine build with recent V8 versions

### DIFF
--- a/src/script/v8/engine.cpp
+++ b/src/script/v8/engine.cpp
@@ -254,7 +254,7 @@ public:
     auto isolate = args.GetIsolate();
     v8::HandleScope handle_scope(isolate);
     auto data = args.Data().As<v8::External>();
-    auto& func = *reinterpret_cast<script::Function*>(data->Value());
+    auto& func = *reinterpret_cast<script::Function*>(data->Value(v8::kExternalPointerTypeTagDefault));
 
     for (int i = 0; i < args.Length(); i++) {
       func.arguments.push_back(getValue(isolate, args[i]));
@@ -274,7 +274,7 @@ public:
     auto isolate = m_engine.get<V8Engine>()->m_isolate;
     auto context = m_engine.get<V8Engine>()->context();
     for (auto& entry : functions) {
-      auto tpl = v8::FunctionTemplate::New(isolate, callFunc, v8::External::New(isolate, &entry.second));
+      auto tpl = v8::FunctionTemplate::New(isolate, callFunc, v8::External::New(isolate, &entry.second, v8::kExternalPointerTypeTagDefault));
       auto func = tpl->GetFunction(context).ToLocalChecked();
       Check(object->Set(context,
                   ToLocal(v8::String::NewFromUtf8(isolate, entry.first.c_str())),
@@ -287,10 +287,10 @@ public:
     auto context = m_engine.get<V8Engine>()->context();
 
     for (auto& entry : properties) {
-      auto getterTpl = v8::FunctionTemplate::New(isolate, callFunc, v8::External::New(isolate, &entry.second.getter));
+      auto getterTpl = v8::FunctionTemplate::New(isolate, callFunc, v8::External::New(isolate, &entry.second.getter, v8::kExternalPointerTypeTagDefault));
       auto getter = getterTpl->GetFunction(context).ToLocalChecked();
 
-      auto setterTpl = v8::FunctionTemplate::New(isolate, callFunc, v8::External::New(isolate, &entry.second.setter));
+      auto setterTpl = v8::FunctionTemplate::New(isolate, callFunc, v8::External::New(isolate, &entry.second.setter, v8::kExternalPointerTypeTagDefault));
       auto setter = setterTpl->GetFunction(context).ToLocalChecked();
 
       v8::PropertyDescriptor descriptor(getter, setter);


### PR DESCRIPTION
## Problem

On my Mac, when going through the compilation instructions, when running `ninja libresprite` the `src/script/v8/engine.cpp` fails to compile against recent V8 headers (tested with V8 14.8.178.14) with errors like:

```
error: too few arguments to function call, single argument 'tag' was not specified
    auto& func = *reinterpret_cast<script::Function*>(data->Value());
```

The V8 API changed `v8::External::New()` and `v8::External::Value()` to require an `ExternalPointerTypeTag` parameter for pointer type safety.

<details><summary>Full stack trace</summary>
```
-std=c++20 -arch arm64 -MD -MT src/script/CMakeFiles/script-lib.dir/v8/engine.cpp.o -MF src/script/CMakeFiles/script-lib.dir/v8/engine.cpp.o.d -o src/script/CMakeFiles/script-lib.dir/v8/engine.cpp.o
 -c /Users/tomas/workspace/third-party/LibreSprite/src/script/v8/engine.cpp
 /Users/tomas/workspace/third-party/LibreSprite/src/script/v8/engine.cpp:257:67: error: too few arguments to function call, single argument 'tag' was not specified
   257 |     auto& func = *reinterpret_cast<script::Function*>(data->Value());
       |                                                       ~~~~~~~~~~~ ^
 /opt/homebrew/include/v8-external.h:58:9: note: 'Value' declared here
    58 |   void* Value(ExternalPointerTypeTag tag) const;
       |         ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~
 /Users/tomas/workspace/third-party/LibreSprite/src/script/v8/engine.cpp:277:103: error: too few arguments to function call, expected 3, have 2
   277 |       auto tpl = v8::FunctionTemplate::New(isolate, callFunc, v8::External::New(isolate, &entry.second));
       |                                                               ~~~~~~~~~~~~~~~~~                       ^
 /opt/homebrew/include/v8-external.h:41:26: note: 'New' declared here
    41 |   static Local<External> New(Isolate* isolate, void* value,
       |                          ^   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    42 |                              ExternalPointerTypeTag tag);
       |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~
 /Users/tomas/workspace/third-party/LibreSprite/src/script/v8/engine.cpp:290:116: error: too few arguments to function call, expected 3, have 2
   290 |       auto getterTpl = v8::FunctionTemplate::New(isolate, callFunc, v8::External::New(isolate, &entry.second.getter));
       |                                                                     ~~~~~~~~~~~~~~~~~                              ^
 /opt/homebrew/include/v8-external.h:41:26: note: 'New' declared here
    41 |   static Local<External> New(Isolate* isolate, void* value,
       |                          ^   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    42 |                              ExternalPointerTypeTag tag);
       |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~
 /Users/tomas/workspace/third-party/LibreSprite/src/script/v8/engine.cpp:293:116: error: too few arguments to function call, expected 3, have 2
   293 |       auto setterTpl = v8::FunctionTemplate::New(isolate, callFunc, v8::External::New(isolate, &entry.second.setter));
       |                                                                     ~~~~~~~~~~~~~~~~~                              ^
 /opt/homebrew/include/v8-external.h:41:26: note: 'New' declared here
    41 |   static Local<External> New(Isolate* isolate, void* value,
       |                          ^   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    42 |                              ExternalPointerTypeTag tag);
       |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~
 4 errors generated.
 ninja: build stopped: subcommand failed.
```

</details>

## Fix

Pass `v8::kExternalPointerTypeTagDefault` to all four affected call sites:

- `data->Value()` on line 257
- `v8::External::New(isolate, ...)` on lines 277, 290, and 293

This is the default tag value.

### Disclaimer

I asked AI to fix the local build. So this small script fix is AI-generated
