### PR TITLE
Fix Remove Layer being greyed out when layer is hidden or locked

### DIFF
--- a/src/app/commands/cmd_remove_layer.cpp
+++ b/src/app/commands/cmd_remove_layer.cpp
@@ -45,9 +45,7 @@ bool RemoveLayerCommand::onEnabled(Context* context)
 {
   return context->checkFlags(ContextFlags::ActiveDocumentIsWritable |
                              ContextFlags::HasActiveSprite |
-                             ContextFlags::HasActiveLayer |
-                             ContextFlags::ActiveLayerIsVisible |
-                             ContextFlags::ActiveLayerIsEditable);
+                             ContextFlags::HasActiveLayer);
 }
 
 void RemoveLayerCommand::onExecute(Context* context)


### PR DESCRIPTION
Goal of the PR: Fix "Remove Layer" being greyed out when a layer is hidden or locked.

How does it work: Removes ActiveLayerIsVisible and ActiveLayerIsEditable from onEnabled() in RemoveLayerCommand. Neither flag is needed — onExecute() already guards against deleting the last layer, and there's no technical reason a hidden or locked layer can't be removed.

Resolves #622.

**How to test**
1. Create a new layer
2. Hide it (toggle the eye icon)
3. Right-click the layer → "Remove" should no longer be greyed out
4. Also test with a locked layer (padlock icon)
