### PR TITLE
reduce 'unknown windowevent' stdout spam

### DIFF
--- a/src/she/sdl2/she.cpp
+++ b/src/she/sdl2/she.cpp
@@ -437,6 +437,16 @@ namespace she {
               break;
             }
           }
+          //silence 'Unknown windowevent' console spam for common SDL window events
+          case SDL_WINDOWEVENT_SHOWN:
+          case SDL_WINDOWEVENT_HIDDEN:
+          case SDL_WINDOWEVENT_MOVED:
+          case SDL_WINDOWEVENT_ENTER:
+          case SDL_WINDOWEVENT_FOCUS_GAINED:
+          case SDL_WINDOWEVENT_FOCUS_LOST:
+          case SDL_WINDOWEVENT_CLOSE: 
+          //closing the app is handled elsewhere so we can ignore it here
+            continue;
 
           default:
             std::cout << "Unknown windowevent: " << (int) sdlEvent.window.event << std::endl;


### PR DESCRIPTION
Currently, master spams 'Unknown windowevent' to stdout for very common SDL WindowEvents, including `SDL_WINDOWEVENT_MOVED` which fires every frame. This pull request silences those events, so it is easier to see other things which LibreSprite might print to stdout.

My platform is linux with x.org. Default build config.
## How to test
Open LibreSprite and observe that moving the window doesn't print numerous lines of 'Unknown windowevent'.