### PR TITLE
Fix Space quicktool shortcut handling

### DIFF
--- a/src/app/ui/editor/editor.cpp
+++ b/src/app/ui/editor/editor.cpp
@@ -167,6 +167,7 @@ Editor::Editor(Document* document, EditorFlags flags)
   , m_docView(NULL)
   , m_flags(flags)
   , m_secondaryButton(false)
+  , m_spacePressed(false)
   , m_aniSpeed(1.0)
 {
   // Add the first state into the history.
@@ -1183,6 +1184,7 @@ bool Editor::onProcessMessage(Message* msg)
 
         m_oldPos = mouseMsg->position();
         updateToolByTipProximity(mouseMsg->pointerType());
+        updateQuicktool();
 
         if (!m_secondaryButton && mouseMsg->right()) {
           m_secondaryButton = mouseMsg->right();
@@ -1255,6 +1257,9 @@ bool Editor::onProcessMessage(Message* msg)
 
     case kKeyDownMessage:
       if (m_sprite) {
+        if (static_cast<KeyMessage*>(msg)->scancode() == kKeySpace)
+          m_spacePressed = true;
+
         EditorStatePtr holdState(m_state);
         bool used = m_state->onKeyDown(this, static_cast<KeyMessage*>(msg));
 
@@ -1271,6 +1276,9 @@ bool Editor::onProcessMessage(Message* msg)
 
     case kKeyUpMessage:
       if (m_sprite) {
+        if (static_cast<KeyMessage*>(msg)->scancode() == kKeySpace)
+          m_spacePressed = false;
+
         EditorStatePtr holdState(m_state);
         bool used = m_state->onKeyUp(this, static_cast<KeyMessage*>(msg));
 
@@ -1288,6 +1296,7 @@ bool Editor::onProcessMessage(Message* msg)
     case kFocusLeaveMessage:
       // As we use keys like Space-bar as modifier, we can clear the
       // keyboard buffer when we lost the focus.
+      m_spacePressed = false;
       she::clear_keyboard_buffer();
       break;
 

--- a/src/app/ui/editor/editor.h
+++ b/src/app/ui/editor/editor.h
@@ -177,6 +177,7 @@ namespace app {
     tools::ToolLoopModifiers getToolLoopModifiers() const { return m_toolLoopModifiers; }
     bool isAutoSelectLayer() const { return m_autoSelectLayer; }
     bool isSecondaryButton() const { return m_secondaryButton; }
+    bool isSpacePressed() const { return m_spacePressed; }
 
     gfx::Point lastDrawingPosition() const { return m_lastDrawingPosition; }
     void setLastDrawingPosition(const gfx::Point& pos);
@@ -324,6 +325,7 @@ namespace app {
     EditorFlags m_flags;
 
     bool m_secondaryButton;
+    bool m_spacePressed;
 
     // Animation speed multiplier.
     double m_aniSpeed;

--- a/src/app/ui/editor/standby_state.cpp
+++ b/src/app/ui/editor/standby_state.cpp
@@ -22,6 +22,7 @@
 #include "app/tools/ink.h"
 #include "app/tools/pick_ink.h"
 #include "app/tools/tool.h"
+#include "app/tools/tool_box.h"
 #include "app/ui/document_view.h"
 #include "app/ui/editor/drawing_state.h"
 #include "app/ui/editor/editor.h"
@@ -35,6 +36,7 @@
 #include "app/ui/editor/tool_loop_impl.h"
 #include "app/ui/editor/transform_handles.h"
 #include "app/ui/editor/zooming_state.h"
+#include "app/ui/keyboard_shortcuts.h"
 #include "app/ui/main_window.h"
 #include "app/ui/skin/skin_theme.h"
 #include "app/ui/status_bar.h"
@@ -48,6 +50,7 @@
 #include "doc/sprite.h"
 #include "fixmath/fixmath.h"
 #include "gfx/rect.h"
+#include "she/keys.h"
 #include "she/surface.h"
 #include "ui/alert.h"
 #include "ui/message.h"
@@ -126,9 +129,28 @@ void StandbyState::onActiveToolChange(Editor* editor, tools::Tool* tool)
 bool StandbyState::checkForScroll(Editor* editor, MouseMessage* msg)
 {
   tools::Ink* clickedInk = editor->getCurrentEditorInk().get();
+  tools::Tool* handTool = App::instance()->toolBox()->getToolById(
+    tools::WellKnownTools::Hand);
+  Key* handQuicktool = KeyboardShortcuts::instance()->quicktool(handTool);
+  const bool handQuicktoolPressed = handQuicktool && handQuicktool->isPressed();
+  const bool handQuicktoolHasSpace =
+    handQuicktool &&
+    (handQuicktool->hasAccel(ui::Accelerator(ui::kKeySpaceModifier,
+                                             ui::kKeyNil,
+                                             0)) ||
+     handQuicktool->hasAccel(ui::Accelerator(ui::kKeyNoneModifier,
+                                             ui::kKeySpace,
+                                             0)));
+  const bool spacePressed =
+    editor->isSpacePressed() ||
+    (msg->modifiers() & ui::kKeySpaceModifier) ||
+    she::is_key_pressed(ui::kKeySpace);
 
   // Start scroll loop
-  if (msg->middle() || clickedInk->isScrollMovement()) { // TODO msg->middle() should be customizable
+  if (msg->middle() ||
+      clickedInk->isScrollMovement() ||
+      (handQuicktool && (handQuicktoolPressed ||
+                         (spacePressed && handQuicktoolHasSpace)))) { // TODO msg->middle() should be customizable
     EditorStatePtr newState(new ScrollingState());
     editor->setState(newState);
 

--- a/src/app/ui/keyboard_shortcuts.cpp
+++ b/src/app/ui/keyboard_shortcuts.cpp
@@ -208,6 +208,9 @@ void Key::add(const ui::Accelerator& accel, KeySource source)
   Accelerators* accels = &m_accels;
 
   if (source == KeySource::UserDefined) {
+    if (!m_useUsers && m_accels.has(accel))
+      return;
+
     if (!m_useUsers) {
       m_useUsers = true;
       m_users = m_accels;

--- a/src/net/CMakeLists.txt
+++ b/src/net/CMakeLists.txt
@@ -5,5 +5,10 @@ add_library(net-lib
   http_request.cpp
   http_response.cpp)
 
-target_link_libraries(net-lib
-  ${CURL_LIBRARIES})
+if(TARGET CURL::libcurl)
+  target_link_libraries(net-lib
+    PUBLIC CURL::libcurl)
+else()
+  target_link_libraries(net-lib
+    PUBLIC ${CURL_LIBRARIES})
+endif()

--- a/src/she/sdl2/she.cpp
+++ b/src/she/sdl2/she.cpp
@@ -73,6 +73,7 @@ static std::unordered_map<int, she::Event::MouseButton> mouseButtonMapping = {
 };
 static she::KeyScancode lastScancode;
 static int lastScancodeSDL;
+static bool syntheticSpacePressed = false;
 struct Modifier {
   const int sheModifier;
   int ascii;
@@ -81,6 +82,7 @@ struct Modifier {
 };
 
 static std::unordered_map<int, Modifier*> reverseKeyCodeMapping;
+static std::unordered_map<int, SDL_Keycode> reverseSDLKeyCodeMapping;
 
 static std::unordered_map<SDL_Keycode, Modifier> keyCodeMapping = {
   {SDLK_UNKNOWN, she::kKeyNil},
@@ -234,10 +236,28 @@ std::unordered_map<SDL_Keycode, Modifier> modifiers = {
 she::KeyModifiers getSheModifiers() {
   int mod = 0;
   for (auto& entry : modifiers) {
-    if (entry.second.isPressed)
+    const Uint8* keyboardState = SDL_GetKeyboardState(nullptr);
+    SDL_Scancode scancode = SDL_GetScancodeFromKey(entry.first);
+    if (entry.second.isPressed ||
+        (scancode != SDL_SCANCODE_UNKNOWN && keyboardState[scancode]))
       mod |= entry.second.sheModifier;
   }
+  if (syntheticSpacePressed)
+    mod |= she::kKeySpaceModifier;
   return (she::KeyModifiers) mod;
+}
+
+static void setSyntheticSpacePressed(bool pressed)
+{
+  syntheticSpacePressed = pressed;
+
+  auto keyIt = keyCodeMapping.find(SDLK_SPACE);
+  if (keyIt != keyCodeMapping.end())
+    keyIt->second.isPressed = pressed;
+
+  auto modIt = modifiers.find(SDLK_SPACE);
+  if (modIt != modifiers.end())
+    modIt->second.isPressed = pressed;
 }
 
 #ifdef __EMSCRIPTEN__
@@ -321,6 +341,7 @@ namespace she {
       if (reverseKeyCodeMapping.empty()) {
         for (auto& entry : keyCodeMapping) {
           reverseKeyCodeMapping[entry.second.sheModifier] = &entry.second;
+          reverseSDLKeyCodeMapping[entry.second.sheModifier] = entry.first;
           entry.second.ascii = entry.first;
         }
       }
@@ -443,7 +464,10 @@ namespace she {
           case SDL_WINDOWEVENT_MOVED:
           case SDL_WINDOWEVENT_ENTER:
           case SDL_WINDOWEVENT_FOCUS_GAINED:
+            continue;
           case SDL_WINDOWEVENT_FOCUS_LOST:
+            setSyntheticSpacePressed(false);
+            continue;
           case SDL_WINDOWEVENT_CLOSE: 
           //closing the app is handled elsewhere so we can ignore it here
             continue;
@@ -499,6 +523,10 @@ namespace she {
 
         case SDL_MOUSEBUTTONUP:
         case SDL_MOUSEBUTTONDOWN: {
+          if (sdlEvent.type == SDL_MOUSEBUTTONUP && syntheticSpacePressed) {
+            setSyntheticSpacePressed(false);
+          }
+
           auto type = sdlEvent.type == SDL_MOUSEBUTTONDOWN ? Event::MouseDown : Event::MouseUp;
           event.setType(type);
           event.setPosition({
@@ -550,12 +578,17 @@ namespace she {
             continue;
           }
 
+          const bool textInputWasActive = SDL_IsTextInputActive();
           event.setType(isPressed ? Event::KeyDown : Event::KeyUp);
           auto modifiers = getSheModifiers();
           event.setModifiers(modifiers);
           it->second.isPressed = isPressed;
           auto scancode = static_cast<she::KeyScancode>(it->second.sheModifier);
           event.setScancode(scancode);
+          if (scancode == she::kKeySpace) {
+            if (!isPressed)
+              syntheticSpacePressed = false;
+          }
           if (isPressed) {
             lastScancode = scancode;
             lastScancodeSDL = sdlEvent.key.keysym.scancode;
@@ -567,7 +600,7 @@ namespace she {
           if (modifiers & (she::kKeyCtrlModifier | she::kKeyCmdModifier)) {
             SDL_StopTextInput();
             break;
-          } else if (!SDL_IsTextInputActive()) {
+          } else if (!textInputWasActive && scancode != she::kKeySpace) {
             SDL_StartTextInput();
           }
           continue;
@@ -594,8 +627,24 @@ namespace she {
           continue;
 
         case SDL_TEXTINPUT: {
-          keybuffer.clear();
           std::string textString = sdlEvent.text.text;
+          if (lastScancode == she::kKeySpace && textString == " ") {
+            lastScancodeSDL = SDL_SCANCODE_UNKNOWN;
+            continue;
+          }
+
+          if (textString == " ") {
+            setSyntheticSpacePressed(true);
+
+            Event event;
+            event.setType(Event::KeyDown);
+            event.setModifiers(getSheModifiers());
+            event.setScancode(she::kKeySpace);
+            keybuffer.push_back(event);
+            continue;
+          }
+
+          keybuffer.clear();
           base::utf8_const_iterator begin{textString.begin()};
           base::utf8_const_iterator end{textString.end()};
           Event event;
@@ -928,7 +977,15 @@ namespace she {
   bool is_key_pressed(KeyScancode scancode) {
     auto it = reverseKeyCodeMapping.find(scancode);
     if (it != reverseKeyCodeMapping.end()) {
-      return it->second->isPressed;
+      if (it->second->isPressed)
+        return true;
+
+      auto sdlIt = reverseSDLKeyCodeMapping.find(scancode);
+      if (sdlIt != reverseSDLKeyCodeMapping.end()) {
+        const Uint8* keyboardState = SDL_GetKeyboardState(nullptr);
+        SDL_Scancode sdlScancode = SDL_GetScancodeFromKey(sdlIt->second);
+        return (sdlScancode != SDL_SCANCODE_UNKNOWN && keyboardState[sdlScancode]);
+      }
     }
     return false;
   }

--- a/src/ui/accelerator.cpp
+++ b/src/ui/accelerator.cpp
@@ -42,6 +42,7 @@ static KeyModifiers get_pressed_modifiers_from_she()
   if (she::is_key_pressed(kKeyRControl)) mods = KeyModifiers(int(mods) | int(kKeyCtrlModifier));
   if (she::is_key_pressed(kKeyAlt)     ) mods = KeyModifiers(int(mods) | int(kKeyAltModifier));
   if (she::is_key_pressed(kKeyCommand) ) mods = KeyModifiers(int(mods) | int(kKeyCmdModifier));
+  if (she::is_key_pressed(kKeySpace)   ) mods = KeyModifiers(int(mods) | int(kKeySpaceModifier));
   if (she::is_key_pressed(kKeyLWin)    ) mods = KeyModifiers(int(mods) | int(kKeyWinModifier));
   if (she::is_key_pressed(kKeyRWin)    ) mods = KeyModifiers(int(mods) | int(kKeyWinModifier));
   return mods;
@@ -213,6 +214,11 @@ Accelerator::Accelerator(const std::string& str)
         m_scancode = kKeyEnterPad;
     }
   }
+
+  if (m_scancode == kKeySpace) {
+    m_modifiers = KeyModifiers(int(m_modifiers) | int(kKeySpaceModifier));
+    m_scancode = kKeyNil;
+  }
 }
 
 bool Accelerator::operator==(const Accelerator& other) const
@@ -379,6 +385,16 @@ std::string Accelerator::toString() const
 
 bool Accelerator::isPressed(KeyModifiers modifiers, KeyScancode scancode, int unicodeChar) const
 {
+  if (scancode == kKeySpace &&
+      m_scancode == kKeyNil &&
+      m_unicodeChar == 0 &&
+      (m_modifiers & kKeySpaceModifier)) {
+    return (m_modifiers == modifiers);
+  }
+
+  if (scancode == kKeySpace)
+    modifiers = KeyModifiers(int(modifiers) & ~int(kKeySpaceModifier));
+
   // Preprocess the character to be compared with the accelerator
 #ifdef PREPROCESS_KEYS
   // Directly scancode
@@ -459,6 +475,9 @@ bool Accelerator::isPressed(KeyModifiers modifiers, KeyScancode scancode, int un
 bool Accelerator::isPressed() const
 {
   KeyModifiers modifiers = get_pressed_modifiers_from_she();
+
+  if (m_scancode == kKeySpace)
+    modifiers = KeyModifiers(int(modifiers) & ~int(kKeySpaceModifier));
 
   return ((m_scancode == 0 || she::is_key_pressed(m_scancode)) &&
           (m_modifiers == modifiers));

--- a/src/ui/accelerator_ui_tests.cpp
+++ b/src/ui/accelerator_ui_tests.cpp
@@ -26,6 +26,8 @@ TEST(Accelerator, Parser)
   EXPECT_EQ(Accelerator(kKeyNoneModifier, kKeyPlusPad, 0), Accelerator("Plus Pad"));
   EXPECT_EQ(Accelerator(kKeyNoneModifier, kKeyPlusPad, 0), Accelerator("+ Pad"));
   EXPECT_EQ(Accelerator(kKeyCtrlModifier, kKeyPlusPad, 0), Accelerator("Ctrl++ Pad"));
+  EXPECT_EQ(Accelerator(kKeySpaceModifier, kKeyNil, 0), Accelerator("Space"));
+  EXPECT_EQ(Accelerator(kKeySpaceModifier, kKeyLeft, 0), Accelerator("Space+Left"));
 }
 
 TEST(Accelerator, ToString)
@@ -53,4 +55,17 @@ TEST(Accelerator, ToString)
   EXPECT_EQ("+ Pad", Accelerator(kKeyNoneModifier, kKeyPlusPad, 0).toString());
   EXPECT_EQ("+ Pad", Accelerator("Plus Pad").toString());
   EXPECT_EQ("+ Pad", Accelerator("+ Pad").toString());
+}
+
+TEST(Accelerator, IsPressedWithSpace)
+{
+  EXPECT_TRUE(Accelerator(kKeyNoneModifier, kKeySpace, 0).isPressed(
+    kKeySpaceModifier, kKeySpace, 0));
+  EXPECT_TRUE(Accelerator(kKeySpaceModifier, kKeyNil, 0).isPressed(
+    kKeySpaceModifier, kKeySpace, 0));
+  EXPECT_TRUE(Accelerator(kKeySpaceModifier, kKeyLeft, 0).isPressed(
+    kKeySpaceModifier, kKeyLeft, 0));
+
+  EXPECT_FALSE(Accelerator(kKeySpaceModifier, kKeyNil, 0).isPressed(
+    KeyModifiers(int(kKeyShiftModifier) | int(kKeySpaceModifier)), kKeySpace, 0));
 }


### PR DESCRIPTION
## Summary
- Treat Space-only accelerators as modifier-only shortcuts so quicktools saved through the shortcut dialog match the default Space binding.
- Preserve Space modifier state when SDL reports Space as text input instead of a keydown event.
- Let Space-configured Hand quicktool start canvas scrolling even when the selected drawing tool would otherwise handle the drag.
- Link `net-lib` against CMake's imported `CURL::libcurl` target when available so the full app links cleanly on newer CMake/libcurl setups.

## Testing
- Built with Ninja on Fedora KDE.
- Verified clean launch: Space-drag pans canvas without resetting shortcuts.
- Verified removing and re-adding Hand quicktool with only the Space modifier checkbox works immediately and after restart.
- Verified default behavior in Ubuntu 26.04 VM and patched behavior after re-adding Space shortcut.
- Ran `ninja -C /home/aj/dev/LibreSprite/build ui-lib app-lib libresprite`.
