### PR TITLE
Palette organizer, Line-tool input coalescing, and Android build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,14 +113,18 @@ set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib)
 # Debug C/C++ flags
 if(CMAKE_BUILD_TYPE STREQUAL Debug)
   add_definitions(-DDEBUGMODE -D_DEBUG)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -g")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0 -g")
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -O0 -g")
+  if(NOT MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -g")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0 -g")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -O0 -g")
+  endif()
 else()
   add_definitions(-DNDEBUG)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3")
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -O3")
+  if(NOT MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -O3")
+  endif()
 endif()
 
 # Fix to compile gtest with VC11 (2012)
@@ -142,6 +146,17 @@ include_directories(${QOI_DIR})
 # tinyxml2
 find_library(TINYXML2_LIBRARY NAMES tinyxml2)
 find_path(TINYXML2_INCLUDE_DIR NAMES tinyxml2.h)
+if((NOT TINYXML2_INCLUDE_DIR OR NOT TINYXML2_LIBRARY) AND EXISTS "${CMAKE_SOURCE_DIR}/android/tinyxml2/tinyxml2.cpp")
+  # No system tinyxml2 (e.g. the Windows host codegen build): compile the copy
+  # bundled in the Android deps so gen has something to link against. Built by
+  # CMake itself so it shares the same MSVC runtime as the rest of the build.
+  message(STATUS "System tinyxml2 not found; building bundled android/tinyxml2")
+  add_library(tinyxml2_bundled STATIC ${CMAKE_SOURCE_DIR}/android/tinyxml2/tinyxml2.cpp)
+  set_target_properties(tinyxml2_bundled PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  target_include_directories(tinyxml2_bundled PUBLIC ${CMAKE_SOURCE_DIR}/android/tinyxml2)
+  set(TINYXML2_LIBRARY tinyxml2_bundled)
+  set(TINYXML2_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/android/tinyxml2)
+endif()
 include_directories(${TINYXML2_INCLUDE_DIR})
 
 if(NOT GEN_ONLY)
@@ -260,10 +275,14 @@ set(PLATFORM_LIBS)
 if(USE_SDL2_BACKEND)
   add_definitions(-DUSE_SDL2_BACKEND)
 
-  find_package(SDL2 REQUIRED)
-  include_directories(${SDL2_INCLUDE_DIRS})
-  find_package(SDL2_IMAGE REQUIRED)
-  include_directories(${SDL2_IMAGE_INCLUDE_DIRS})
+  # SDL2 is only needed to build the actual app; the GEN_ONLY codegen pass
+  # (which produces C++ from XML) does not link against it.
+  if(NOT GEN_ONLY)
+    find_package(SDL2 REQUIRED)
+    include_directories(${SDL2_INCLUDE_DIRS})
+    find_package(SDL2_IMAGE REQUIRED)
+    include_directories(${SDL2_IMAGE_INCLUDE_DIRS})
+  endif()
 endif()
 
 # -- Unix --

--- a/data/widgets/palette_popup.xml
+++ b/data/widgets/palette_popup.xml
@@ -5,7 +5,9 @@
     <label text="Available Palettes:" />
     <view id="view" expansive="true" />
     <hbox>
-      <button id="load_pal" text="Load" width="80" />
+      <button id="load_pal" text="Load" width="70" />
+      <button id="rename_pal" text="Rename" width="70" />
+      <button id="delete_pal" text="Delete" width="70" />
       <hbox expansive="true" />
       <button id="open_folder" text="Open Folder" width="60" />
     </hbox>

--- a/src/app/commands/cmd_load_palette.cpp
+++ b/src/app/commands/cmd_load_palette.cpp
@@ -16,7 +16,9 @@
 #include "app/file/palette_file.h"
 #include "app/file_selector.h"
 #include "app/modules/palettes.h"
+#include "app/ui/color_bar.h"
 #include "base/fs.h"
+#include "base/path.h"
 #include "doc/palette.h"
 #include "ui/alert.h"
 
@@ -75,6 +77,21 @@ void LoadPaletteCommand::onExecute(Context* context)
       auto cmd = static_cast<SetPaletteCommand*>(CommandsModule::instance()->getCommandByName(CommandId::SetPalette));
       cmd->setPalette(palette.get());
       context->executeCommand(cmd);
+
+      // When the palette was loaded from a user-chosen file (not an existing
+      // preset), copy it into the user palettes directory so it is added
+      // permanently to the "Available palettes" list.
+      if (m_preset.empty()) {
+        std::string title = base::get_file_title(filename);
+        if (!title.empty()) {
+          std::string dest = get_preset_palette_filename(title, ".gpl");
+          if (save_palette(dest.c_str(), *palette, 0)) {
+            // Rebuild the palettes popup so the new entry appears immediately.
+            if (ColorBar* colorBar = ColorBar::instance())
+              colorBar->invalidatePalettePopup();
+          }
+        }
+      }
     }
   }
 }

--- a/src/app/commands/cmd_save_palette.cpp
+++ b/src/app/commands/cmd_save_palette.cpp
@@ -60,7 +60,10 @@ void SavePaletteCommand::onExecute(Context* context)
   }
   else {
     std::string exts = get_writable_palette_extensions();
-    filename = app::show_file_selector("Save Palette", "", exts,
+    // Default the dialog to the user palettes folder so a saved palette lands
+    // where "Available palettes" looks for it, instead of an app-private dir.
+    std::string initialPath = get_preset_palette_filename("Untitled", ".gpl");
+    filename = app::show_file_selector("Save Palette", initialPath, exts,
                                        FileSelectorType::Save);
     if (filename.empty())
       return;

--- a/src/app/file/palette_file.cpp
+++ b/src/app/file/palette_file.cpp
@@ -17,6 +17,7 @@
 #include "base/path.h"
 #include "base/string.h"
 #include "doc/cel.h"
+#include "doc/file/ase_swatch_file.h"
 #include "doc/file/col_file.h"
 #include "doc/file/gpl_file.h"
 #include "doc/file/pal_file.h"
@@ -59,6 +60,12 @@ std::shared_ptr<Palette> load_palette(const char *filename)
   }
   else if (ext == "pal") {
     pal = doc::file::load_pal_file(filename);
+  }
+  else if ((pal = doc::file::load_ase_swatch_file(filename))) {
+    // Adobe Swatch Exchange (.ase) palette: handled above. The .ase extension
+    // is shared with Aseprite sprites, so load_ase_swatch_file() only succeeds
+    // when the file actually carries the "ASEF" signature; otherwise it returns
+    // null and we fall through to the document/sprite loader below.
   }
   else {
     FileFormat* ff = FileFormatsManager::instance()->getFileFormatByExtension(ext.c_str());

--- a/src/app/resource_finder.cpp
+++ b/src/app/resource_finder.cpp
@@ -163,7 +163,19 @@ void ResourceFinder::includeHomeDir(const char* filename)
 
 void ResourceFinder::includeUserDir(const char* filename)
 {
-#ifdef _WIN32
+#ifdef __ANDROID__
+
+  // On Android, store user files in a public, file-manager-accessible folder
+  // (the app has All-files access) so palettes/config persist across "clear
+  // cache" and can be managed by the user. EXTERNAL_STORAGE is set by Android
+  // to the primary shared storage (e.g. /sdcard or /storage/emulated/0).
+  {
+    const char* ext = std::getenv("EXTERNAL_STORAGE");
+    std::string sdcard = (ext && *ext) ? std::string(ext) : std::string("/storage/emulated/0");
+    addPath(base::join_path(base::join_path(sdcard, "LibreSprite"), filename).c_str());
+  }
+
+#elif defined(_WIN32)
 
   if (App::instance()->isPortable()) {
     // $BINDIR/filename

--- a/src/app/ui/color_bar.cpp
+++ b/src/app/ui/color_bar.cpp
@@ -259,6 +259,13 @@ ColorBar::~ColorBar()
   UIContext::instance()->removeObserver(this);
 }
 
+void ColorBar::invalidatePalettePopup()
+{
+  // Drop the cached popup; it is recreated (and the palette list re-scanned)
+  // the next time the user opens "Available palettes".
+  m_palettePopup.reset();
+}
+
 void ColorBar::setPixelFormat(PixelFormat pixelFormat)
 {
   m_fgColor.setPixelFormat(pixelFormat);
@@ -493,26 +500,26 @@ void ColorBar::onPaletteButtonClick()
     }
 
     case PalButton::PRESETS: {
-      if (!m_palettePopup) {
-        try {
-          m_palettePopup.reset(new PalettePopup());
-        }
-        catch (const std::exception& ex) {
-          Console::showException(ex);
-          return;
-        }
-      }
-
-      if (!m_palettePopup->isVisible()) {
-        gfx::Rect bounds = m_buttons.getItem(item)->bounds();
-
-        m_palettePopup->showPopup(
-          gfx::Rect(bounds.x, bounds.y+bounds.h,
-                    ui::display_w()/2, ui::display_h()/2));
-      }
-      else {
+      if (m_palettePopup && m_palettePopup->isVisible()) {
         m_palettePopup->closeWindow(NULL);
+        break;
       }
+
+      // Recreate the popup each time it opens so the palette list re-scans the
+      // folder and reflects palettes added or removed on disk (including via a
+      // file manager).
+      try {
+        m_palettePopup.reset(new PalettePopup());
+      }
+      catch (const std::exception& ex) {
+        Console::showException(ex);
+        return;
+      }
+
+      gfx::Rect bounds = m_buttons.getItem(item)->bounds();
+      m_palettePopup->showPopup(
+        gfx::Rect(bounds.x, bounds.y+bounds.h,
+                  ui::display_w()/2, ui::display_h()/2));
       break;
     }
 

--- a/src/app/ui/color_bar.h
+++ b/src/app/ui/color_bar.h
@@ -58,6 +58,10 @@ namespace app {
     ColorBar(int align);
     ~ColorBar();
 
+    // Discards the cached "Available palettes" popup so it is rebuilt (and the
+    // palette list re-scanned) the next time it is opened.
+    void invalidatePalettePopup();
+
     void setPixelFormat(PixelFormat pixelFormat);
 
     app::Color getFgColor();

--- a/src/app/ui/palette_listbox.h
+++ b/src/app/ui/palette_listbox.h
@@ -17,6 +17,7 @@ in the Filesystem.
 
 #pragma once
 
+#include "app/file_system.h"
 #include "app/res/resources_loader.h"
 #include "base/injection.h"
 #include "doc/palette.h"
@@ -44,6 +45,9 @@ namespace app {
   class PaletteFileListBox : public PaletteListBox {
   public:
     PaletteFileListBox() {
+      // Drop cached directory listings so a freshly-built list reflects palettes
+      // added/removed on disk (including by a file manager) since last time.
+      FileSystemModule::instance()->refresh();
       setLoading(true);
       m_resourcesLoader->load([this](Resource palResource){
         if (palResource) {

--- a/src/app/ui/palette_popup.cpp
+++ b/src/app/ui/palette_popup.cpp
@@ -16,10 +16,17 @@
 #include "app/launcher.h"
 #include "app/ui_context.h"
 #include "base/bind.h"
+#include "base/fs.h"
+#include "base/launcher.h"
+#include "base/path.h"
+#include "doc/palette.h"
+#include "ui/alert.h"
 #include "ui/box.h"
 #include "ui/button.h"
+#include "ui/entry.h"
 #include "ui/theme.h"
 #include "ui/view.h"
+#include "ui/window.h"
 
 #include "palette_popup.xml.h"
 
@@ -37,6 +44,8 @@ PalettePopup::PalettePopup()
   addChild(m_popup);
 
   m_popup->loadPal()->Click.connect(base::Bind<void>(&PalettePopup::onLoadPal, this));
+  m_popup->renamePal()->Click.connect(base::Bind<void>(&PalettePopup::onRenamePal, this));
+  m_popup->deletePal()->Click.connect(base::Bind<void>(&PalettePopup::onDeletePal, this));
   m_popup->openFolder()->Click.connect(base::Bind<void>(&PalettePopup::onOpenFolder, this));
 
   m_popup->view()->attachToView(&m_paletteListBox);
@@ -48,6 +57,8 @@ PalettePopup::PalettePopup()
 void PalettePopup::showPopup(const gfx::Rect& bounds)
 {
   m_popup->loadPal()->setEnabled(false);
+  m_popup->renamePal()->setEnabled(false);
+  m_popup->deletePal()->setEnabled(false);
   m_paletteListBox.selectChild(NULL);
 
   moveWindow(bounds);
@@ -60,9 +71,11 @@ void PalettePopup::showPopup(const gfx::Rect& bounds)
 
 void PalettePopup::onPalChange(doc::Palette* palette)
 {
+  const bool hasSelection = (palette != NULL);
   m_popup->loadPal()->setEnabled(
-    UIContext::instance()->activeDocument() &&
-    palette != NULL);
+    UIContext::instance()->activeDocument() && hasSelection);
+  m_popup->renamePal()->setEnabled(hasSelection);
+  m_popup->deletePal()->setEnabled(hasSelection);
 }
 
 void PalettePopup::onLoadPal()
@@ -77,12 +90,119 @@ void PalettePopup::onLoadPal()
   UIContext::instance()->executeCommand(cmd);
 }
 
+// Small modal dialog asking for a new palette name. Returns an empty string if
+// cancelled.
+static std::string ask_for_palette_name(const std::string& current)
+{
+  Window window(Window::WithTitleBar, "Rename Palette");
+  Box* box = new VBox();
+  Entry* entry = new Entry(256, "%s", current.c_str());
+  Box* buttons = new HBox();
+  Button* ok = new Button("&OK");
+  Button* cancel = new Button("&Cancel");
+
+  entry->setExpansive(true);
+  ok->Click.connect(base::Bind<void>(&Window::closeWindow, &window, ok));
+  cancel->Click.connect(base::Bind<void>(&Window::closeWindow, &window, cancel));
+
+  buttons->addChild(ok);
+  buttons->addChild(cancel);
+  box->addChild(entry);
+  box->addChild(buttons);
+  window.addChild(box);
+
+  window.remapWindow();
+  window.centerWindow();
+  window.openWindowInForeground();
+
+  if (window.closer() == ok)
+    return entry->text();
+  return std::string();
+}
+
+void PalettePopup::onRenamePal()
+{
+  doc::Palette* palette = m_paletteListBox.selectedPalette();
+  if (!palette)
+    return;
+
+  std::string fn = palette->filename();
+  if (fn.empty())
+    return;
+
+  std::string oldTitle = base::get_file_title(fn);
+  std::string ext = base::get_file_extension(fn);
+  std::string dir = base::get_file_path(fn);
+
+  std::string newTitle = ask_for_palette_name(oldTitle);
+  if (newTitle.empty() || newTitle == oldTitle)
+    return;
+
+  std::string newFn = base::join_path(dir, newTitle + "." + ext);
+  try {
+    base::move_file(fn, newFn);
+  }
+  catch (const std::exception&) {
+    Alert::show("Error<<Could not rename the palette file.||&Close");
+    return;
+  }
+
+  palette->setFilename(newFn);
+  if (Widget* item = m_paletteListBox.getSelectedChild())
+    item->setText(newTitle);
+  m_paletteListBox.layout();
+}
+
+void PalettePopup::onDeletePal()
+{
+  doc::Palette* palette = m_paletteListBox.selectedPalette();
+  if (!palette)
+    return;
+
+  std::string fn = palette->filename();
+  std::string name = m_paletteListBox.selectedPaletteName();
+  if (fn.empty())
+    return;
+
+  if (Alert::show("Delete Palette"
+                  "<<Delete \"%s\" permanently?"
+                  "||&Delete||&Cancel", name.c_str()) != 1)
+    return;
+
+  try {
+    if (base::is_file(fn))
+      base::delete_file(fn);
+  }
+  catch (const std::exception&) {
+    Alert::show("Error<<Could not delete the palette file.||&Close");
+    return;
+  }
+
+  // Remove the entry from the list immediately.
+  if (Widget* item = m_paletteListBox.getSelectedChild()) {
+    m_paletteListBox.removeChild(item);
+    item->deferDelete();
+  }
+  m_paletteListBox.selectChild(NULL);
+  onPalChange(NULL);
+  if (View* view = View::getView(&m_paletteListBox))
+    view->updateView();
+  m_paletteListBox.layout();
+}
+
 void PalettePopup::onOpenFolder()
 {
   inject<ResourcesLoader> loader{"palette"};
   auto paths = loader->resourcesLocation();
-  if (!paths.empty())
-      launcher::open_folder(paths.back());
+  if (paths.empty())
+    return;
+
+  const std::string& folder = paths.back();
+  if (!base::launcher::open_folder(folder)) {
+    // No file manager handled the request: show the path so the user can
+    // browse to it (it lives in accessible shared storage).
+    Alert::show("Palettes folder<<%s||&OK", folder.c_str());
+  }
 }
 
 } // namespace app

--- a/src/app/ui/palette_popup.h
+++ b/src/app/ui/palette_popup.h
@@ -30,6 +30,8 @@ namespace app {
   protected:
     void onPalChange(doc::Palette* palette);
     void onLoadPal();
+    void onRenamePal();
+    void onDeletePal();
     void onOpenFolder();
 
   private:

--- a/src/base/dll_unix.h
+++ b/src/base/dll_unix.h
@@ -6,7 +6,11 @@
 
 #include "base/string.h"
 
-#ifdef HAVE_DLFCN_H
+// HAVE_DLFCN_H comes from the host-generated config.h, which may be produced on
+// a platform without dlfcn.h (e.g. the Windows codegen host) even when the
+// actual target (Android/Linux/macOS) always provides it. Fall back to the
+// known-present header on those targets.
+#if defined(HAVE_DLFCN_H) || defined(__ANDROID__) || defined(__unix__) || defined(__linux__) || defined(__APPLE__)
   #include <dlfcn.h>
 #else
   #error dlfcn.h is needed or include a file that defines dlopen/dlclose

--- a/src/base/launcher.cpp
+++ b/src/base/launcher.cpp
@@ -65,6 +65,28 @@ static int win32_shell_execute(const wchar_t* verb, const wchar_t* file, const w
 }
 #endif  // _WIN32
 
+#ifdef __ANDROID__
+#include <jni.h>
+extern "C" JNIEnv* Android_JNI_GetEnv(void);
+extern "C" jclass Android_JNI_GetActivityClass(void);
+namespace {
+bool android_open_folder(const std::string& path)
+{
+  JNIEnv* env = Android_JNI_GetEnv();
+  jclass cls = Android_JNI_GetActivityClass();
+  if (!env || !cls)
+    return false;
+  jmethodID mid = env->GetStaticMethodID(cls, "openFolder", "(Ljava/lang/String;)Z");
+  if (!mid)
+    return false;
+  jstring jpath = env->NewStringUTF(path.c_str());
+  jboolean ok = env->CallStaticBooleanMethod(cls, mid, jpath);
+  env->DeleteLocalRef(jpath);
+  return ok == JNI_TRUE;
+}
+} // namespace
+#endif  // __ANDROID__
+
 namespace base {
 namespace launcher {
 
@@ -132,6 +154,12 @@ bool open_folder(const std::string& _file)
     ret = std::system(("open --reveal \"" + file + "\"").c_str());
   }
   return (ret == 0);
+
+#elif defined(__ANDROID__)
+
+  if (!base::is_directory(file))
+    file = base::get_file_path(file);
+  return android_open_folder(file);
 
 #else
 

--- a/src/doc/CMakeLists.txt
+++ b/src/doc/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(doc-lib
   conversion_she.cpp
   document.cpp
   documents.cpp
+  file/ase_swatch_file.cpp
   file/col_file.cpp
   file/gpl_file.cpp
   file/pal_file.cpp

--- a/src/doc/file/ase_swatch_file.cpp
+++ b/src/doc/file/ase_swatch_file.cpp
@@ -1,0 +1,159 @@
+// Aseprite Document Library
+//
+// This file is released under the terms of the MIT license.
+// Read LICENSE.txt for more information.
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "doc/color.h"
+#include "doc/palette.h"
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+namespace doc {
+namespace file {
+
+namespace {
+
+// Adobe Swatch Exchange is a big-endian format.
+uint16_t read_u16_be(FILE* f) {
+  int hi = std::fgetc(f);
+  int lo = std::fgetc(f);
+  return (uint16_t)(((hi & 0xff) << 8) | (lo & 0xff));
+}
+
+uint32_t read_u32_be(FILE* f) {
+  uint32_t b0 = (uint32_t)std::fgetc(f);
+  uint32_t b1 = (uint32_t)std::fgetc(f);
+  uint32_t b2 = (uint32_t)std::fgetc(f);
+  uint32_t b3 = (uint32_t)std::fgetc(f);
+  return ((b0 & 0xff) << 24) | ((b1 & 0xff) << 16) | ((b2 & 0xff) << 8) | (b3 & 0xff);
+}
+
+float read_f32_be(FILE* f) {
+  uint32_t u = read_u32_be(f);
+  float v;
+  std::memcpy(&v, &u, sizeof(v));
+  return v;
+}
+
+uint8_t to_byte(float v) {
+  long n = std::lround(v * 255.0f);
+  if (n < 0) n = 0;
+  if (n > 255) n = 255;
+  return (uint8_t)n;
+}
+
+// CIELAB (D50) -> sRGB, for the rare .ase files that store Lab colors.
+void lab_to_rgb(float L, float a, float b, uint8_t& R, uint8_t& G, uint8_t& B) {
+  float fy = (L + 16.0f) / 116.0f;
+  float fx = fy + a / 500.0f;
+  float fz = fy - b / 200.0f;
+  auto finv = [](float t) {
+    float t3 = t * t * t;
+    return (t3 > 0.008856f) ? t3 : (t - 16.0f / 116.0f) / 7.787f;
+  };
+  // D50 reference white.
+  float X = 0.96422f * finv(fx);
+  float Y = 1.00000f * finv(fy);
+  float Z = 0.82521f * finv(fz);
+  // XYZ (D50) -> linear sRGB (Bradford-adapted matrix).
+  float r =  3.1338561f * X - 1.6168667f * Y - 0.4906146f * Z;
+  float g = -0.9787684f * X + 1.9161415f * Y + 0.0334540f * Z;
+  float bl =  0.0719453f * X - 0.2289914f * Y + 1.4052427f * Z;
+  auto gamma = [](float c) {
+    if (c <= 0.0f) return 0.0f;
+    if (c >= 1.0f) return 1.0f;
+    return (c <= 0.0031308f) ? 12.92f * c : 1.055f * std::pow(c, 1.0f / 2.4f) - 0.055f;
+  };
+  R = to_byte(gamma(r));
+  G = to_byte(gamma(g));
+  B = to_byte(gamma(bl));
+}
+
+} // anonymous namespace
+
+std::shared_ptr<Palette> load_ase_swatch_file(const char* filename) {
+  FILE* f = std::fopen(filename, "rb");
+  if (!f)
+    return nullptr;
+
+  char sig[4];
+  if (std::fread(sig, 1, 4, f) != 4 || std::memcmp(sig, "ASEF", 4) != 0) {
+    std::fclose(f);
+    return nullptr;            // Not an Adobe Swatch Exchange file.
+  }
+
+  read_u16_be(f);              // version major
+  read_u16_be(f);              // version minor
+  uint32_t blockCount = read_u32_be(f);
+
+  std::vector<color_t> colors;
+  for (uint32_t i = 0; i < blockCount; ++i) {
+    uint16_t type = read_u16_be(f);
+    uint32_t length = read_u32_be(f);
+    long blockStart = std::ftell(f);
+    if (blockStart < 0 || std::feof(f))
+      break;
+
+    if (type == 0x0001) {      // Color entry
+      uint16_t nameLen = read_u16_be(f);          // UTF-16 units incl. null
+      std::fseek(f, (long)nameLen * 2, SEEK_CUR); // skip the swatch name
+
+      char model[4] = {0};
+      std::fread(model, 1, 4, f);
+      uint8_t r = 0, g = 0, b = 0;
+      if (std::memcmp(model, "RGB ", 4) == 0) {
+        r = to_byte(read_f32_be(f));
+        g = to_byte(read_f32_be(f));
+        b = to_byte(read_f32_be(f));
+      }
+      else if (std::memcmp(model, "Gray", 4) == 0) {
+        r = g = b = to_byte(read_f32_be(f));
+      }
+      else if (std::memcmp(model, "CMYK", 4) == 0) {
+        float c = read_f32_be(f), m = read_f32_be(f);
+        float y = read_f32_be(f), k = read_f32_be(f);
+        r = to_byte((1.0f - c) * (1.0f - k));
+        g = to_byte((1.0f - m) * (1.0f - k));
+        b = to_byte((1.0f - y) * (1.0f - k));
+      }
+      else if (std::memcmp(model, "LAB ", 4) == 0) {
+        float L = read_f32_be(f) * 100.0f;        // stored 0..1
+        float A = read_f32_be(f);                 // stored -128..127
+        float Bc = read_f32_be(f);
+        lab_to_rgb(L, A, Bc, r, g, b);
+      }
+      else {
+        // Unknown color model: skip this color but keep parsing.
+        std::fseek(f, blockStart + (long)length, SEEK_SET);
+        continue;
+      }
+      colors.push_back(rgba(r, g, b, 255));
+    }
+
+    // Always seek to the declared end of the block (handles groups, the
+    // trailing color-type field, and any padding).
+    std::fseek(f, blockStart + (long)length, SEEK_SET);
+  }
+
+  std::fclose(f);
+
+  if (colors.empty())
+    return nullptr;
+
+  std::shared_ptr<Palette> pal = Palette::create((int)colors.size());
+  for (int i = 0; i < (int)colors.size(); ++i)
+    pal->setEntry(i, colors[i]);
+  return pal;
+}
+
+} // namespace file
+} // namespace doc

--- a/src/doc/file/ase_swatch_file.h
+++ b/src/doc/file/ase_swatch_file.h
@@ -1,0 +1,22 @@
+// Aseprite Document Library
+//
+// This file is released under the terms of the MIT license.
+// Read LICENSE.txt for more information.
+
+#pragma once
+
+#include <memory>
+
+namespace doc {
+
+  class Palette;
+
+  namespace file {
+
+    // Loads an Adobe Swatch Exchange (.ase) palette file. The .ase extension is
+    // shared with Aseprite sprites, so this returns nullptr if the file is not
+    // an "ASEF" swatch (letting the caller fall back to the sprite loader).
+    std::shared_ptr<Palette> load_ase_swatch_file(const char* filename);
+
+  } // namespace file
+} // namespace doc

--- a/src/she/sdl2/she.cpp
+++ b/src/she/sdl2/she.cpp
@@ -462,6 +462,30 @@ namespace she {
             m_events.push(ev);
           }
 
+          // Coalesce a contiguous run of pending motion events into the most
+          // recent sample. A high-rate pen/touch device (e.g. the Samsung S
+          // Pen, or a finger) otherwise floods the SDL queue faster than the
+          // tools can consume it, so the Line tool's preview lags further and
+          // further behind the real cursor.
+          //
+          // On Android every pen/finger sample arrives as BOTH an
+          // SDL_FINGERMOTION (pressure) and a synthesized SDL_MOUSEMOTION
+          // (position), interleaved in the queue, so we must collapse a run of
+          // *either* type -- keeping the latest mouse position and the latest
+          // pen pressure. We stop at the first non-motion event so ordering
+          // relative to button/key events is preserved.
+          {
+            SDL_Event peek;
+            while (SDL_PeepEvents(&peek, 1, SDL_PEEKEVENT, SDL_FIRSTEVENT, SDL_LASTEVENT) == 1 &&
+                   (peek.type == SDL_MOUSEMOTION || peek.type == SDL_FINGERMOTION)) {
+              SDL_PeepEvents(&peek, 1, SDL_GETEVENT, peek.type, peek.type);
+              if (peek.type == SDL_MOUSEMOTION)
+                sdlEvent.motion = peek.motion;
+              else
+                penPressure = std::max(peek.tfinger.pressure, 0.0001f);
+            }
+          }
+
           event.setType(Event::MouseMove);
           event.setModifiers(getSheModifiers());
           event.setPosition({


### PR DESCRIPTION
Desktop/cross-platform changes from the LibreSprite V1.2 Android effort (companion to the Android-side PR in `ls-android-deps`). Three independent commits, splittable on request. Rebased onto current `master`.

### 1. Palette: .ase swatch import, save/delete, and linked saved palettes
Adds reading of Adobe Swatch Exchange (.ase) palette files (`doc/file/ase_swatch_file`) plus Save/Delete palette commands. Loaded and saved palettes are written to the user palettes folder and linked into the **Available palettes** list, so they appear there directly instead of having to be re-loaded from a file each time. (This is not a new full palette-organizer UI — just the swatch format, save/delete, and the link-into-Available-palettes behaviour.)

### 2. Line tool: coalesce high-rate pointer input to stop preview lag
The SDL backend emitted one `MouseMove` per `SDL_MOUSEMOTION` with no coalescing, so a high-rate pen/touch device floods the event queue faster than the tools can drain it and the Line-tool preview lags further and further behind the cursor. This collapses a contiguous run of pending motion events — both `SDL_MOUSEMOTION` and the interleaved `SDL_FINGERMOTION` Android emits per sample — into the latest position/pressure before emitting a single `MouseMove`. Adaptive (nothing dropped unless already behind) and stops at the first non-motion event so button/key ordering is preserved. General improvement; benefits any SDL platform with a high-rate input device. Verified on a Samsung Galaxy Tab S7 FE (S Pen): eliminated the input-buffer lockup.

### 3. Android build & platform support
Compiles the bundled `android/tinyxml2` when no system tinyxml2 is found (Windows codegen host), skips `SDL2 find_package` during the `GEN_ONLY` codegen pass, and guards GCC-only debug/release flags behind `NOT MSVC`. Falls back to `<dlfcn.h>` on Android/unix/Apple when the host-generated `config.h` lacks `HAVE_DLFCN_H`, stores user files under `EXTERNAL_STORAGE/LibreSprite` on Android, and implements `base::open_folder` via the `MainActivity.openFolder` JNI call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)